### PR TITLE
feat: outline for LType arbitrary and shrink

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use a library that is not on stackage, you'll need to update the common-stanza
 CP1:
 - [x] Define type `datatype`.
 - [x] Create bare-bones `LuTypeChecker` module.
-- [ ] Outline arbitrary and shrink for `LType`.
+- [x] Outline arbitrary and shrink for `LType`.
 - [ ] Unit tests for `synthesis`.
 - [ ] quickCheck tests for `synthesis`.
 - [ ] Unit tests for `checker`.

--- a/src/LuTypes.hs
+++ b/src/LuTypes.hs
@@ -1,4 +1,6 @@
 module LuTypes where
+import Test.QuickCheck (Arbitrary (..), Gen)
+
 
 
 -- Potentially add Unknown, Any as we see fit. 
@@ -12,3 +14,10 @@ data LType =
     | UnionType LType LType 
     | FunctionType LType LType -- Partial Function 
     deriving (Eq, Show)
+
+instance Arbitrary LType where
+    arbitrary :: Gen LType
+    arbitrary = undefined
+
+    shrink :: LType -> [LType]
+    shrink = undefined


### PR DESCRIPTION
This change outlines the `arbitrary` and `shrink` functions for `LType` to be used in QuickCheck testing.