### PR TITLE
refactor: generalize notion of `environment` across type checker and evaluator. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,16 @@ CP2:
 - [x] Implement `checker`. 
 - [x] Implement `synthesis`.
 - [x] Implement `typeCheckBlock` and `typeCheckStatement`.
-- [ ] Generalize store used in evaluator to use `Environment`. (Harry)
+- [x] Generalize store used in evaluator to use `Environment`. (Harry)
 - [ ] Tweak parser (and typechecker) to allow functions called straight from tables. (Harry)
 - [ ] Build some nice demo/ui to show that it works. 
 
 Potential Extensions:
-- [ ] Be able to check types within stepper. 
-- [ ] Proper lexical scoping for function calls. 
+- [ ] Implement Local variables. 
+- [ ] Lexical Scoping for functions. 
+- [ ] Be able to check types within stepper.  
 - [ ] User Defined types.
+- [ ] Type assertions / coercions
 - [ ] Allow optional types in tables and functions. 
 - [ ] Other things?
 

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -9,8 +9,6 @@ import LuSyntax
 import State (State)
 import qualified State as S
 
-
-
 data Context a = Context {
     gMap :: Map Value a, 
     localStack :: Stack (LocalVar a),  

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -76,6 +76,13 @@ class Environment a v where
         Just lv -> Just $ val lv 
         _ -> Nothing
 
+    prepareFunctionEnv :: [(Name, v)] -> State a ()
+    prepareFunctionEnv params = do 
+        let getThisContext = getContext :: a -> Context v
+        S.modify (\env -> setContext env (enterScope (getThisContext env)))
+        S.modify (\e -> foldr addLocal e params)
+    
+
 -- | Decrease depth of scope and remove variables at this level. 
 exitScope :: Context a -> Context a
 exitScope c = c {localStack = Stack.popUntil (localStack c) (aboveDepth (curDepth c)), curDepth = curDepth c - 1} where 

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -38,9 +38,9 @@ class Environment a v where
     update :: Reference -> v -> State a ()
     update (GlobalRef n) v = S.modify (addGlobal (n, v)) 
     update (LocalRef n) v = S.modify (addLocal (n, v))
-    update t v = updateTable t v 
+    update (TableRef n k) v = updateTable (n, k) v 
 
-    updateTable :: Reference -> v -> State a () 
+    updateTable :: (Name, Value) -> v -> State a () 
 
     addLocal :: (Name, v) -> a -> a 
     addLocal (n, v) env = let c = getContext env in

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -10,17 +10,31 @@ import State (State)
 import qualified State as S
 
 
+
 data Context a = Context {
     gMap :: Map Value a, 
     localStack :: Stack (LocalVar a),  
     curDepth :: Int
 }
 
+data Reference = 
+    GlobalRef Name -- name of global
+  | LocalRef Name  -- name of local
+  | TableRef Name Value  -- name of table, value that keys it. 
+  deriving (Eq, Show)
+
 data LocalVar a = LocalVar {
     val :: a,
     name :: Name,
     depth :: Int
 }
+
+
+
+class Environment a v where 
+    index :: Reference -> State a v 
+    update :: Reference -> v -> State a ()
+
 
 addGlobal :: (Name, a) -> Context a -> Context a
 addGlobal (k, v) c = c {gMap = Map.insert (StringVal k) v (gMap c)}

--- a/src/LuEvaluator.hs
+++ b/src/LuEvaluator.hs
@@ -48,9 +48,10 @@ instance Environment EvalEnv Value where
         Just v -> v 
         _ -> NilVal 
       _ -> NilVal
+  
     
-  updateTable :: Reference -> Value -> State EvalEnv ()
-  updateTable (TableRef tname tkey) v = do 
+  updateTable :: (Name, Value) -> Value -> State EvalEnv ()
+  updateTable (tname, tkey) v = do 
     mTable <- tableFromState tname
     S.modify (updateTableHelper mTable) where 
       updateTableHelper :: Maybe Table -> EvalEnv -> EvalEnv 

--- a/src/LuEvaluator.hs
+++ b/src/LuEvaluator.hs
@@ -61,12 +61,6 @@ instance Environment EvalEnv Value where
         Nothing -> env 
         Just t -> env {tableMap = Map.insert tname (Map.insert tkey v t) (tableMap env)}
 
--- enterEnvScope :: EvalEnv -> EvalEnv 
--- enterEnvScope env = env {context = C.enterScope (context env)}
-
--- exitEnvScope :: EvalEnv -> EvalEnv 
--- exitEnvScope env = env {context = C.exitScope (context env)}
-
 resolveVar :: Var -> State EvalEnv (Maybe Reference)
 resolveVar (Name n) = do 
   env <- S.get

--- a/src/LuEvaluator.hs
+++ b/src/LuEvaluator.hs
@@ -147,25 +147,6 @@ tableFromState :: Name -> State EvalEnv (Maybe Table)
 tableFromState tname | tname == globalTableName = Just . C.gMap . context <$> S.get
 tableFromState tname = Map.lookup tname . tableMap <$> S.get
 
--- index :: Reference -> State EvalEnv Value
--- index (GlobalRef n) = do 
---   env <- S.get 
---   return $ case C.getGlobal n env of 
---     Just v -> v 
---     _ -> NilVal
--- index (LocalRef n) = do 
---   env <- S.get 
---   return $ case C.getLocal n env of 
---     Just v -> v 
---     _ -> NilVal 
--- index (TableRef tname tkey) = do 
---   env <- S.get 
---   return $ case Map.lookup tname (tableMap env) of 
---     Just table -> case Map.lookup tkey table of 
---       Just v -> v 
---       _ -> NilVal 
---     _ -> NilVal
-
 allocateTable :: [(Value, Value)] -> State EvalEnv Value
 allocateTable assocs = do
   env <- S.get

--- a/src/LuEvaluator.hs
+++ b/src/LuEvaluator.hs
@@ -82,9 +82,11 @@ resolveVar (Proj exp1 exp2) = do
     (TableVal t1, v) -> Just (TableRef t1 v)
     _ -> Nothing
 
+-- | Helper function to convert evaluation environment to Store (for testing and debugging)
 toStore :: EvalEnv -> Store
 toStore env = Map.insert globalTableName (C.gMap (context env)) (tableMap env)
 
+-- | Helper function to convert Store to evaluation environment (for testing and debugging)
 fromStore :: Store -> EvalEnv 
 fromStore s = case Map.lookup globalTableName s of 
   Nothing -> C.emptyContext -- Shouldn't hit this cae.  
@@ -261,11 +263,6 @@ getTableSize v = do
   return $ case Map.lookup v (tableMap s) of 
     Just t -> Just $ length t
     _ -> Nothing
-
-
-  -- S.get >>= \s -> return $ do
-  --   targetTable <- Map.lookup v (toStore s)
-  --   return $ length targetTable
 
 evalOp1 :: Uop -> Value -> State EvalEnv Value
 evalOp1 Neg (IntVal v) = return $ IntVal $ negate v

--- a/src/LuEvaluator.hs
+++ b/src/LuEvaluator.hs
@@ -147,24 +147,24 @@ tableFromState :: Name -> State EvalEnv (Maybe Table)
 tableFromState tname | tname == globalTableName = Just . C.gMap . context <$> S.get
 tableFromState tname = Map.lookup tname . tableMap <$> S.get
 
-index :: Reference -> State EvalEnv Value
-index (GlobalRef n) = do 
-  env <- S.get 
-  return $ case C.getGlobal n env of 
-    Just v -> v 
-    _ -> NilVal
-index (LocalRef n) = do 
-  env <- S.get 
-  return $ case C.getLocal n env of 
-    Just v -> v 
-    _ -> NilVal 
-index (TableRef tname tkey) = do 
-  env <- S.get 
-  return $ case Map.lookup tname (tableMap env) of 
-    Just table -> case Map.lookup tkey table of 
-      Just v -> v 
-      _ -> NilVal 
-    _ -> NilVal
+-- index :: Reference -> State EvalEnv Value
+-- index (GlobalRef n) = do 
+--   env <- S.get 
+--   return $ case C.getGlobal n env of 
+--     Just v -> v 
+--     _ -> NilVal
+-- index (LocalRef n) = do 
+--   env <- S.get 
+--   return $ case C.getLocal n env of 
+--     Just v -> v 
+--     _ -> NilVal 
+-- index (TableRef tname tkey) = do 
+--   env <- S.get 
+--   return $ case Map.lookup tname (tableMap env) of 
+--     Just table -> case Map.lookup tkey table of 
+--       Just v -> v 
+--       _ -> NilVal 
+--     _ -> NilVal
 
 allocateTable :: [(Value, Value)] -> State EvalEnv Value
 allocateTable assocs = do
@@ -194,7 +194,7 @@ evalE e = do
     doEvalE (Var v) = do
       mr <- resolveVar v -- see above
       case mr of
-        Just r -> index r
+        Just r -> C.index r
         Nothing -> return NilVal
     doEvalE (Val v) = return v
     doEvalE (Op2 e1 o e2) = do evalOp2 o <$> evalE e1 <*> evalE e2

--- a/src/LuStepper.hs
+++ b/src/LuStepper.hs
@@ -9,6 +9,7 @@ import Text.Read (readMaybe)
 import Data.List qualified as List
 import State (State)
 import State qualified as S
+import Context qualified as C
 import Data.Map (Map, (!?))
 import Data.Map qualified as Map
 import Test.HUnit (Counts, Test (..), runTestTT, (~:), (~?=))
@@ -69,7 +70,7 @@ initialStepper =
   Stepper
     { filename = Nothing,
       block = mempty,
-      env = emptyEvalEnv,
+      env = C.emptyContext,
       history = Nothing
     }
 

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -27,21 +27,16 @@ instance Environment TypeEnv LType where
     setContext :: TypeEnv -> Context LType -> TypeEnv 
     setContext env newContext = env {context = newContext}
 
-    index :: Reference -> State TypeEnv LType
-    index (GlobalRef n) = do 
-        env <- S.get 
-        return $ case C.getGlobal n env of 
-            Just v -> v 
-            _ -> NilType
-    index (LocalRef n) = do 
-        env <- S.get 
-        return $ case C.getLocal n env of 
-            Just v -> v 
-            _ -> UnknownType 
-    index (TableRef tname tkey) = return UnknownType
+    index :: Reference -> State TypeEnv LType 
+    index r@(GlobalRef _) = C.indexWithDefault r NilType  
+    index r@(LocalRef _) = C.indexWithDefault r UnknownType
+    index r = C.indexWithDefault r NilType
+
+    indexTable :: (Name, Value) -> LType -> State TypeEnv LType
+    indexTable _ = return
 
     updateTable :: (Name, Value) -> LType -> State TypeEnv ()
-    updateTable (tname, tkey) v = return ()
+    updateTable _ _ = return ()
 
 contextLookup :: Name -> State TypeEnv LType 
 contextLookup n = do 

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -55,7 +55,7 @@ addGlobalToEnv :: (Name, LType) -> TypeEnv -> TypeEnv
 addGlobalToEnv keyValuePair env = env {context = C.addGlobal keyValuePair (context env)}
 
 setGMap :: TypeEnv -> Map Name LType -> TypeEnv 
-setGMap env m = env {context = C.setGMap (context env) m}
+setGMap env m = env {context = C.setGMap (context env) (Map.mapKeys StringVal m)}
 
 type TypecheckerState a = State TypeEnv (Either String a)
 

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -69,12 +69,6 @@ getUncalledFunc env n = Map.lookup n (uncalledFuncs env)
 removeUncalledFunc :: TypeEnv -> Name -> TypeEnv 
 removeUncalledFunc env n = env {uncalledFuncs = Map.delete n (uncalledFuncs env)}
 
--- enterEnvScope :: TypeEnv -> TypeEnv 
--- enterEnvScope env = env {context = C.enterScope (context env)}
-
--- exitEnvScope :: TypeEnv -> TypeEnv 
--- exitEnvScope env = env {context = C.exitScope (context env)}
-
 type TypecheckerState a = State TypeEnv (Either String a)
 
 class Synthable a where 

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -40,8 +40,8 @@ instance Environment TypeEnv LType where
             _ -> UnknownType 
     index (TableRef tname tkey) = return UnknownType
 
-    updateTable :: Reference -> LType -> State TypeEnv ()
-    updateTable (TableRef tname tkey) v = return ()
+    updateTable :: (Name, Value) -> LType -> State TypeEnv ()
+    updateTable (tname, tkey) v = return ()
 
 contextLookup :: Name -> State TypeEnv LType 
 contextLookup n = do 

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -95,7 +95,7 @@ instance Synthable Value where
     synth (StringVal _) = return $ return StringType 
     synth (TableVal n) = undefined --what is this case? 
     synth (FunctionVal pms rt b) = do 
-        prepareFunctionEnv pms rt 
+        C.prepareFunctionEnv ((returnTypeName, rt) : pms)
         s <- S.get
         S.modify exitEnvScope
         case S.evalState (typeCheckBlock b) s of 
@@ -152,9 +152,6 @@ instance Synthable [TableField] where
                 (Left l, _, _) -> return $ Left l 
                 (_, Left l, _) -> return $ Left l
                 (_, _, Left l) -> return $ Left l
-
-prepareFunctionEnv :: [Parameter] -> LType -> State TypeEnv ()
-prepareFunctionEnv pms rt = S.modify enterEnvScope >> S.modify (\e -> foldr C.addLocal e ((returnTypeName, rt) : pms))
 
 isPolymorphicBop :: Bop -> Bool
 isPolymorphicBop Eq = True 
@@ -323,7 +320,7 @@ typeCheckFuncBody n = do
     let funcValue = getUncalledFunc s n  
     case funcValue of 
         Just (FunctionVal pms rt b) -> do 
-            prepareFunctionEnv pms rt 
+            C.prepareFunctionEnv ((returnTypeName, rt) : pms)
             S.modify (\env -> removeUncalledFunc env n)
             res <- typeCheckBlock b 
             S.modify exitEnvScope 

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -167,8 +167,8 @@ isPolymorphicBop _ = False
 typeCheckAST :: Block -> Either String () 
 typeCheckAST b = S.evalState (typeCheckBlock b) emptyTypeEnv
 
-runForContext :: Block -> Either String TypeEnv 
-runForContext b = case S.runState (typeCheckBlock b) emptyTypeEnv of 
+runForEnv :: Block -> Either String TypeEnv 
+runForEnv b = case S.runState (typeCheckBlock b) emptyTypeEnv of 
     (Right (), finalStore) -> Right finalStore
     (Left l, finalStore) -> Left l
     

--- a/src/Stack.hs
+++ b/src/Stack.hs
@@ -30,10 +30,17 @@ popUntil stk@(Stack s (x : xs)) f = if f x
 
 -- | Search stack for item by peeking until predicate is true. 
 peekUntil :: Stack a -> (a -> Bool) -> Maybe a 
-peekUntil stk@(Stack _ []) f = Nothing 
+peekUntil (Stack _ []) f = Nothing 
 peekUntil (Stack s (x : xs)) f = if f x 
     then Just x 
     else peekUntil (Stack (s-1) xs) f
+
+-- | Peek with offset N. peekN of 0 is same as peek. 
+peekN :: Stack a -> Int -> Maybe a 
+peekN (Stack _ []) _ = Nothing 
+peekN (Stack _ (x : xs)) 0 = Just x 
+peekN (Stack s (x : xs)) i = peekN (Stack (s-1) xs) (i-1)
+
 
 stackSize :: Stack a -> Int
 stackSize (Stack s _) = s

--- a/test/LuE2ETest.hs
+++ b/test/LuE2ETest.hs
@@ -2,7 +2,7 @@ module LuE2ETest where
 
 import Test.HUnit (Counts, Test (..), runTestTT, (~:), (~?=), assert)
 import LuParser (parseLuFile)
-import LuEvaluator (Store, eval, initialStore, resolveVar, index, globalTableName, EvalEnv, newStore)
+import LuEvaluator (Store, eval, initialEnv, resolveVar, index, globalTableName, EvalEnv, toStore)
 import LuTypeChecker (typeCheckAST, runForContext, getUncalledFunc, TypeEnv, getFromEnv)
 import Context (Context) 
 import Context qualified as C
@@ -18,7 +18,7 @@ runFileForStore fp = do
         (Left _) -> do 
             return $ Left "Failed to parse file"
         (Right ast) -> do 
-            let finalState = S.execState (eval ast) initialStore
+            let finalState = S.execState (eval ast) initialEnv
             return $ Right finalState
 
 -- | Parse and run typechecker on file to get resulting Store (or error message)
@@ -35,7 +35,7 @@ typeCheckFileForStore fp = do
                 Left m -> Left m 
 
 checkVarProperty :: String -> (Value -> Bool) -> EvalEnv -> Either String Bool 
-checkVarProperty targetName property s = case Map.lookup globalTableName (newStore s) of 
+checkVarProperty targetName property s = case Map.lookup globalTableName (toStore s) of 
     Nothing -> Left "Failed to find global table."
     Just globalTable -> case Map.lookup (StringVal targetName) globalTable of 
         Nothing -> Left ("Failed to find" ++ targetName ++  "variable")

--- a/test/LuE2ETest.hs
+++ b/test/LuE2ETest.hs
@@ -2,7 +2,7 @@ module LuE2ETest where
 
 import Test.HUnit (Counts, Test (..), runTestTT, (~:), (~?=), assert)
 import LuParser (parseLuFile)
-import LuEvaluator (Store, eval, index, globalTableName, EvalEnv, toStore)
+import LuEvaluator (Store, eval, globalTableName, EvalEnv, toStore)
 import LuEvaluatorTest (initialEnv)
 import LuTypeChecker (typeCheckAST, runForContext, getUncalledFunc, TypeEnv, contextLookup)
 import Context (Context) 

--- a/test/LuE2ETest.hs
+++ b/test/LuE2ETest.hs
@@ -142,7 +142,7 @@ test_function =
         TestList 
            [
              "function1" ~: testEvalFile "test/lu/function1.lu" (checkVarExistsInStore "foo"), 
-             "function2" ~: testEvalFile "test/lu/function2.lu" (checkVarValuesInStore [("z", IntVal 11), ("x1", NilVal), ("y1", NilVal)]), 
+             "function2" ~: testEvalFile "test/lu/function2.lu" (checkVarValuesInStore [("z", IntVal 11)]), 
              "function3" ~: testEvalFile "test/lu/function3.lu" (checkVarValuesInStore [("z", BoolVal False), ("s", StringVal "True"), ("x", IntVal 1), ("y", IntVal 2), ("result", IntVal (-1))]), 
              "function4" ~: testEvalFile "test/lu/function4.lu" (checkVarValueInStore "z" (IntVal 5)), 
              "function5" ~: testEvalFile "test/lu/function5.lu" (checkVarValuesInStore [("z", StringVal "foo"), ("x", IntVal 1)]), 

--- a/test/LuE2ETest.hs
+++ b/test/LuE2ETest.hs
@@ -194,7 +194,8 @@ test_typeCheck =
                 "nestedFuncReturnTypeBad" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeBad.lu" False,
                 "nestedFuncReturnTypeBad2" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeBad2.lu" False, 
                 "nameShadow" ~: testTypeCheckFile "test/lu/nameShadow.lu" True, 
-                "nameShadowBad" ~: testTypeCheckFile "test/lu/nameShadowBad.lu" False  
+                "nameShadowBad" ~: testTypeCheckFile "test/lu/nameShadowBad.lu" False, 
+                "unionReturn" ~: testTypeCheckFile "test/lu/unionReturn.lu" False 
 
             ]
 

--- a/test/LuE2ETest.hs
+++ b/test/LuE2ETest.hs
@@ -221,8 +221,8 @@ test_error =
     "e2e error" ~: 
         TestList 
             [ 
-                "IllegalArguments1" ~: testEvalFile "test/lu/error1.lu" (checkVarValuesInStore [("x", IntVal 1), ("_H", BoolVal True), ("_E", ErrorVal IllegalArguments)]), 
-                "IllegalArguments1" ~: testEvalFile "test/lu/error2.lu" (checkVarValuesInStore [("x", IntVal 1), ("_H", BoolVal True), ("_E", ErrorVal DivideByZero)]) 
+                "IllegalArguments1" ~: testEvalFile "test/lu/error1.lu" (checkVarValuesInStore [("x", IntVal 1), ("@H", BoolVal True), ("@E", ErrorVal IllegalArguments)]), 
+                "IllegalArguments1" ~: testEvalFile "test/lu/error2.lu" (checkVarValuesInStore [("x", IntVal 1), ("@H", BoolVal True), ("@E", ErrorVal DivideByZero)]) 
             ]
 test :: IO Counts 
 test = runTestTT $ TestList [test_if, test_function, test_typeSig, test_error]

--- a/test/LuE2ETest.hs
+++ b/test/LuE2ETest.hs
@@ -2,7 +2,8 @@ module LuE2ETest where
 
 import Test.HUnit (Counts, Test (..), runTestTT, (~:), (~?=), assert)
 import LuParser (parseLuFile)
-import LuEvaluator (Store, eval, initialEnv, resolveVar, index, globalTableName, EvalEnv, toStore)
+import LuEvaluator (Store, eval, index, globalTableName, EvalEnv, toStore)
+import LuEvaluatorTest (initialEnv)
 import LuTypeChecker (typeCheckAST, runForContext, getUncalledFunc, TypeEnv, getFromEnv)
 import Context (Context) 
 import Context qualified as C

--- a/test/LuEvaluatorTest.hs
+++ b/test/LuEvaluatorTest.hs
@@ -13,17 +13,17 @@ test_index =
   "index tests" ~:
     TestList
       [ -- The global variable "x" is unitialized (i.e. not present in the initial store)
-        S.evalState (index xref) initialStore ~?= NilVal,
+        S.evalState (index xref) initialEnv ~?= NilVal,
         -- But there is a value for "x" available in the extended store
-        S.evalState (index xref) extendedStore ~?= IntVal 3,
+        S.evalState (index xref) extendedEnv ~?= IntVal 3,
         -- If a table name is not found in the store, accessing its reference also returns nil.
-        S.evalState (index yref) initialStore ~?= NilVal,
+        S.evalState (index yref) initialEnv ~?= NilVal,
         -- We should also be able to access "t[1]" in the extended store
-        S.evalState (index yref) extendedStore ~?= BoolVal True,
-        S.evalState (index ("z", NilVal)) extendedStore ~?= NilVal,
+        S.evalState (index yref) extendedEnv ~?= BoolVal True,
+        S.evalState (index ("z", NilVal)) extendedEnv ~?= NilVal,
         -- Updates using the `nil` key are ignored
-        newStore (S.execState (update ("_t1", NilVal) (IntVal 3)) extendedStore) ~?= newStore (extendedStore),
-        S.evalState (index (globalTableName, StringVal "t")) extendedStore ~?= TableVal "_t1"
+        toStore (S.execState (update ("_t1", NilVal) (IntVal 3)) extendedEnv) ~?= toStore (extendedEnv),
+        S.evalState (index (globalTableName, StringVal "t")) extendedEnv ~?= TableVal "_t1"
       ]
 
 test_update :: Test
@@ -31,13 +31,13 @@ test_update =
   "index tests" ~:
     TestList
       [ -- If we assign to x, then we can find its new value
-        S.evalState (update xref (IntVal 4) >> index xref) initialStore ~?= IntVal 4,
+        S.evalState (update xref (IntVal 4) >> index xref) initialEnv ~?= IntVal 4,
         -- If we assign to x, then remove it, we cannot find it anymore
-        S.evalState (update xref (IntVal 4) >> update xref NilVal >> index xref) initialStore ~?= NilVal,
+        S.evalState (update xref (IntVal 4) >> update xref NilVal >> index xref) initialEnv ~?= NilVal,
         -- If we assign to t.y, then we can find its new value
-        S.evalState (update yref (IntVal 5) >> index yref) extendedStore ~?= IntVal 5,
+        S.evalState (update yref (IntVal 5) >> index yref) extendedEnv ~?= IntVal 5,
         -- If we assign nil to t.y, then we cannot find it
-        S.evalState (update yref NilVal >> index yref) extendedStore ~?= NilVal
+        S.evalState (update yref NilVal >> index yref) extendedEnv ~?= NilVal
       ]
 
 test_resolveVar :: Test
@@ -45,80 +45,80 @@ test_resolveVar =
   "resolveVar" ~:
     TestList
       [ -- we should be able to resolve global variable `x` in the initial store, even though it is not defined
-        S.evalState (resolveVar (Name "x")) initialStore ~?= Just ("_G", StringVal "x"),
-        S.evalState (resolveVar (Name "x")) extendedStore ~?= Just ("_G", StringVal "x"),
+        S.evalState (resolveVar (Name "x")) initialEnv ~?= Just ("_G", StringVal "x"),
+        S.evalState (resolveVar (Name "x")) extendedEnv ~?= Just ("_G", StringVal "x"),
         -- But in the case of Dot or Proj, the first argument should evaluate to a
         -- TableVal that is defined in the store. If it does not, then resolveVar
         -- should return Nothing.
-        S.evalState (resolveVar (Dot (Val NilVal) "x")) initialStore ~?= Nothing,
-        S.evalState (resolveVar (Dot (Var (Name "t")) "x")) initialStore ~?= Nothing,
+        S.evalState (resolveVar (Dot (Val NilVal) "x")) initialEnv ~?= Nothing,
+        S.evalState (resolveVar (Dot (Var (Name "t")) "x")) initialEnv ~?= Nothing,
         -- For Proj we also shouldn't project from Nil
-        S.evalState (resolveVar (Proj (Var (Name "t")) (Val NilVal))) extendedStore ~?= Nothing,
+        S.evalState (resolveVar (Proj (Var (Name "t")) (Val NilVal))) extendedEnv ~?= Nothing,
         -- If the table is defined, we should return a reference to it, even when the field is undefined
-        S.evalState (resolveVar (Dot (Var (Name "t")) "z")) extendedStore ~?= Just ("_t1", StringVal "z"),
-        S.evalState (resolveVar (Dot (Var (Name "t")) "y")) extendedStore ~?= Just ("_t1", StringVal "y"),
-        S.evalState (resolveVar (Dot (Var (Name "t2")) "z")) extendedStore ~?= Nothing,
+        S.evalState (resolveVar (Dot (Var (Name "t")) "z")) extendedEnv ~?= Just ("_t1", StringVal "z"),
+        S.evalState (resolveVar (Dot (Var (Name "t")) "y")) extendedEnv ~?= Just ("_t1", StringVal "y"),
+        S.evalState (resolveVar (Dot (Var (Name "t2")) "z")) extendedEnv ~?= Nothing,
         -- and how we refer to the field shouldn't matter
-        S.evalState (resolveVar (Proj (Var (Name "t")) (Val (StringVal "z")))) extendedStore ~?= Just ("_t1", StringVal "z"),
-        S.evalState (resolveVar (Proj (Var (Name "t2")) (Val (StringVal "z")))) extendedStore ~?= Nothing,
-        S.evalState (resolveVar (Proj (Val NilVal) (Val (StringVal "z")))) extendedStore ~?= Nothing
+        S.evalState (resolveVar (Proj (Var (Name "t")) (Val (StringVal "z")))) extendedEnv ~?= Just ("_t1", StringVal "z"),
+        S.evalState (resolveVar (Proj (Var (Name "t2")) (Val (StringVal "z")))) extendedEnv ~?= Nothing,
+        S.evalState (resolveVar (Proj (Val NilVal) (Val (StringVal "z")))) extendedEnv ~?= Nothing
       ]
 
 test_evaluateNot :: Test
 test_evaluateNot =
   "evaluate not" ~:
     TestList
-      [ evaluate (Op1 Not (Val NilVal)) initialStore ~?= BoolVal True,
-        evaluate (Op1 Not (Val (IntVal 3))) initialStore ~?= BoolVal False
+      [ evaluate (Op1 Not (Val NilVal)) initialEnv ~?= BoolVal True,
+        evaluate (Op1 Not (Val (IntVal 3))) initialEnv ~?= BoolVal False
       ]
 
 test_evaluateLen :: Test
 test_evaluateLen =
   "evaluate len" ~:
     TestList
-      [ evaluate (Op1 Len (Val (StringVal "5520"))) extendedStore ~?= IntVal 4,
-        evaluate (Op1 Len (Val (TableVal "_G"))) extendedStore ~?= IntVal 2,
-        evaluate (Op1 Len (Val (TableVal "_t1"))) extendedStore ~?= IntVal 2,
-        evaluate (Op1 Len (Val (TableVal "_t550"))) extendedStore ~?= NilVal,
-        evaluate (Op1 Len (Val (IntVal 5520))) extendedStore ~?= IntVal 5520,
-        evaluate (Op1 Len (Val (BoolVal True))) extendedStore ~?= IntVal 1
+      [ evaluate (Op1 Len (Val (StringVal "5520"))) extendedEnv ~?= IntVal 4,
+        evaluate (Op1 Len (Val (TableVal "_G"))) extendedEnv ~?= IntVal 2,
+        evaluate (Op1 Len (Val (TableVal "_t1"))) extendedEnv ~?= IntVal 2,
+        evaluate (Op1 Len (Val (TableVal "_t550"))) extendedEnv ~?= NilVal,
+        evaluate (Op1 Len (Val (IntVal 5520))) extendedEnv ~?= IntVal 5520,
+        evaluate (Op1 Len (Val (BoolVal True))) extendedEnv ~?= IntVal 1
       ]
 
 test_tableConst :: Test
 test_tableConst =
   "evaluate { x = 3 } " ~:
     TestList
-      [ newStore (S.execState
+      [ toStore (S.execState
           (evalE (TableConst [FieldName "x" (Val (IntVal 3))]))
-          initialStore)
+          initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
                     ("_t1", Map.fromList [(StringVal "x", IntVal 3)])
                   ],
-        newStore (S.execState
+        toStore (S.execState
           (evalE (TableConst [FieldName "x" (Val (IntVal 3)), FieldName "y" (Val (IntVal 5))]))
-          initialStore)
+          initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
                     ("_t1", Map.fromList [(StringVal "x", IntVal 3), (StringVal "y", IntVal 5)])
                   ],
-        newStore (S.execState
+        toStore (S.execState
           (evalE (TableConst [FieldKey (Val (StringVal "x")) (Val (IntVal 3))]))
-          initialStore)
+          initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
                     ("_t1", Map.fromList [(StringVal "x", IntVal 3)])
                   ],
-        newStore (S.execState
+        toStore (S.execState
           (evalE (TableConst [FieldKey (Val (StringVal "x")) (Val (IntVal 3)), FieldName "y" (Val (IntVal 5))]))
-          initialStore)
+          initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
                     ("_t1", Map.fromList [(StringVal "x", IntVal 3), (StringVal "y", IntVal 5)])
                   ],
-        newStore (S.execState
+        toStore (S.execState
           (evalE (TableConst []))
-          initialStore)
+          initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
                     ("_t1", Map.empty)
@@ -129,30 +129,30 @@ test_evalOp2 :: Test
 test_evalOp2 =
   "evaluate Op2" ~:
     TestList
-      [ evaluate (Op2 (Val (IntVal 3)) Plus (Val (IntVal 1))) initialStore ~?= IntVal 4,
-        evaluate (Op2 (Val (IntVal 3)) Minus (Val (IntVal 1))) initialStore ~?= IntVal 2,
-        evaluate (Op2 (Val (IntVal 3)) Times (Val (IntVal 1))) initialStore ~?= IntVal 3,
-        evaluate (Op2 (Val (IntVal 4)) Divide (Val (IntVal 2))) initialStore ~?= IntVal 2,
-        evaluate (Op2 (Val (IntVal 3)) Modulo (Val (IntVal 2))) initialStore ~?= IntVal 1,
-        evaluate (Op2 (Val (IntVal 3)) Eq (Val (IntVal 2))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Eq (Val (IntVal 3))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Gt (Val (IntVal 2))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Gt (Val (IntVal 3))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Gt (Val (IntVal 4))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 3))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 2))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 4))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Lt (Val (IntVal 2))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Lt (Val (IntVal 3))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Lt (Val (IntVal 4))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Le (Val (IntVal 3))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Le (Val (IntVal 2))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 3))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 2))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 4))) initialStore ~?= BoolVal False,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 3))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 2))) initialStore ~?= BoolVal True,
-        evaluate (Op2 (Val (StringVal "hello ")) Concat (Val (StringVal "world!"))) initialStore ~?= StringVal "hello world!"
+      [ evaluate (Op2 (Val (IntVal 3)) Plus (Val (IntVal 1))) initialEnv ~?= IntVal 4,
+        evaluate (Op2 (Val (IntVal 3)) Minus (Val (IntVal 1))) initialEnv ~?= IntVal 2,
+        evaluate (Op2 (Val (IntVal 3)) Times (Val (IntVal 1))) initialEnv ~?= IntVal 3,
+        evaluate (Op2 (Val (IntVal 4)) Divide (Val (IntVal 2))) initialEnv ~?= IntVal 2,
+        evaluate (Op2 (Val (IntVal 3)) Modulo (Val (IntVal 2))) initialEnv ~?= IntVal 1,
+        evaluate (Op2 (Val (IntVal 3)) Eq (Val (IntVal 2))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Eq (Val (IntVal 3))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Gt (Val (IntVal 2))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Gt (Val (IntVal 3))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Gt (Val (IntVal 4))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 3))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 2))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 4))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Lt (Val (IntVal 2))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Lt (Val (IntVal 3))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Lt (Val (IntVal 4))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Le (Val (IntVal 3))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Le (Val (IntVal 2))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 3))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 2))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 4))) initialEnv ~?= BoolVal False,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 3))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (IntVal 3)) Ge (Val (IntVal 2))) initialEnv ~?= BoolVal True,
+        evaluate (Op2 (Val (StringVal "hello ")) Concat (Val (StringVal "world!"))) initialEnv ~?= StringVal "hello world!"
       ]
 
 test_error :: Test 
@@ -160,26 +160,26 @@ test_error =
   "evaluating errors" ~:
     TestList 
     [
-      evaluate (Op2 (Val (IntVal 3)) Plus (Val (StringVal "here"))) initialStore ~?= ErrorVal IllegalArguments, 
-      evaluate (Op2 (Val (IntVal 3)) Plus (Val (BoolVal True))) initialStore ~?= ErrorVal IllegalArguments, 
-      evaluate (Op2 (Val (IntVal 10)) Plus (Val NilVal)) initialStore ~?= ErrorVal IllegalArguments, 
-      evaluate (Op2 (Val (BoolVal True)) Concat (Val NilVal)) initialStore ~?= ErrorVal IllegalArguments, 
-      evaluate (Op2 (Val (IntVal 10)) Times (Val (StringVal "here"))) initialStore ~?= ErrorVal IllegalArguments, 
-      evaluate (Op2 (Val (BoolVal True)) Divide (Val NilVal)) initialStore ~?= ErrorVal IllegalArguments, 
-      evaluate (Op2 (Val (IntVal 10)) Divide (Val (IntVal 0))) initialStore ~?= ErrorVal DivideByZero, 
-      evaluate (Op2 (Val (IntVal 10)) Divide (Op2 (Val (IntVal 5)) Minus (Val (IntVal 5)))) initialStore ~?= ErrorVal DivideByZero
+      evaluate (Op2 (Val (IntVal 3)) Plus (Val (StringVal "here"))) initialEnv ~?= ErrorVal IllegalArguments, 
+      evaluate (Op2 (Val (IntVal 3)) Plus (Val (BoolVal True))) initialEnv ~?= ErrorVal IllegalArguments, 
+      evaluate (Op2 (Val (IntVal 10)) Plus (Val NilVal)) initialEnv ~?= ErrorVal IllegalArguments, 
+      evaluate (Op2 (Val (BoolVal True)) Concat (Val NilVal)) initialEnv ~?= ErrorVal IllegalArguments, 
+      evaluate (Op2 (Val (IntVal 10)) Times (Val (StringVal "here"))) initialEnv ~?= ErrorVal IllegalArguments, 
+      evaluate (Op2 (Val (BoolVal True)) Divide (Val NilVal)) initialEnv ~?= ErrorVal IllegalArguments, 
+      evaluate (Op2 (Val (IntVal 10)) Divide (Val (IntVal 0))) initialEnv ~?= ErrorVal DivideByZero, 
+      evaluate (Op2 (Val (IntVal 10)) Divide (Op2 (Val (IntVal 5)) Minus (Val (IntVal 5)))) initialEnv ~?= ErrorVal DivideByZero
     ]
 
 tExecTest :: Test
 tExecTest =
   "exec wTest" ~:
-    newStore (exec wTest initialStore)
+    toStore (exec wTest initialEnv)
       ~?= Map.fromList [(globalTableName, Map.fromList [(StringVal "x", IntVal 0), (StringVal "y", IntVal 10)])]
 
 tExecFact :: Test
 tExecFact =
   "exec wFact" ~:
-    newStore (exec wFact initialStore)
+    toStore (exec wFact initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList
@@ -194,7 +194,7 @@ tExecFact =
 tExecAbs :: Test
 tExecAbs =
   "exec wAbs" ~:
-    newStore (exec wAbs initialStore)
+    toStore (exec wAbs initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList [(StringVal "x", IntVal 3)]
@@ -204,7 +204,7 @@ tExecAbs =
 tExecTimes :: Test
 tExecTimes =
   "exec wTimes" ~:
-    newStore (exec wTimes initialStore)
+    toStore (exec wTimes initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList [(StringVal "x", IntVal 0), (StringVal "y", IntVal 3), (StringVal "z", IntVal 30)]
@@ -214,7 +214,7 @@ tExecTimes =
 tExecTable :: Test
 tExecTable =
   "exec wTable" ~:
-    newStore (exec wTable initialStore)
+    toStore (exec wTable initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList
@@ -231,7 +231,7 @@ tExecTable =
 tExecBfs :: Test
 tExecBfs = "exec wBfs" ~: TestList [global !? StringVal "found" ~?= Just (BoolVal True)]
   where
-    ss = newStore (exec wBfs initialStore)
+    ss = toStore (exec wBfs initialEnv)
     global = case ss !? globalTableName of
       Just g -> g
       Nothing -> Map.empty
@@ -240,7 +240,7 @@ test :: IO Counts
 test = runTestTT $ TestList [test_error, test_index, test_update, test_resolveVar, test_evaluateNot, test_evaluateLen, test_tableConst, test_evalOp2, tExecTest, tExecAbs, tExecTimes, tExecTable, tExecBfs, tExecFact]
 
 prop_evalE_total :: Expression -> Store -> Bool
-prop_evalE_total e s = case evaluate e (emptyEvalEnv {newStore = s}) of
+prop_evalE_total e s = case evaluate e (fromStore s) of
   NilVal -> True
   IntVal i -> i `seq` True
   BoolVal b -> b `seq` True

--- a/test/LuEvaluatorTest.hs
+++ b/test/LuEvaluatorTest.hs
@@ -19,13 +19,13 @@ extendedEnv = fromStore m where
     [ ( globalTableName,
         Map.fromList
           [ (StringVal "x", IntVal 3),
-            (StringVal "t", TableVal "_t1")
+            (StringVal "t", TableVal "_t0")
           ]
       ),
-      ( "_t1",
+      ( "_t0",
         Map.fromList
           [ (StringVal "y", BoolVal True),
-            (IntVal 2, TableVal "_t1")
+            (IntVal 2, TableVal "_t0")
           ]
       )
     ]
@@ -34,7 +34,7 @@ xref :: Reference
 xref = GlobalRef "x"
 
 yref :: Reference
-yref = TableRef "_t1" (StringVal "y")
+yref = TableRef "_t0" (StringVal "y")
 
 test_index :: Test
 test_index =
@@ -51,7 +51,7 @@ test_index =
         S.evalState (C.index (TableRef "z" NilVal)) extendedEnv ~?= NilVal,
         -- Updates using the `nil` key are ignored
         toStore (S.execState (C.update (TableRef "_t" NilVal) (IntVal 3)) extendedEnv) ~?= toStore extendedEnv,
-        S.evalState (C.index (GlobalRef "t")) extendedEnv ~?= TableVal "_t1"
+        S.evalState (C.index (GlobalRef "t")) extendedEnv ~?= TableVal "_t0"
       ]
 
 test_update :: Test
@@ -83,11 +83,11 @@ test_resolveVar =
         -- For Proj we also shouldn't project from Nil
         S.evalState (resolveVar (Proj (Var (Name "t")) (Val NilVal))) extendedEnv ~?= Nothing,
         -- If the table is defined, we should return a reference to it, even when the field is undefined
-        S.evalState (resolveVar (Dot (Var (Name "t")) "z")) extendedEnv ~?= Just (TableRef "_t1" (StringVal "z")),
-        S.evalState (resolveVar (Dot (Var (Name "t")) "y")) extendedEnv ~?= Just (TableRef "_t1" (StringVal "y")),
+        S.evalState (resolveVar (Dot (Var (Name "t")) "z")) extendedEnv ~?= Just (TableRef "_t0" (StringVal "z")),
+        S.evalState (resolveVar (Dot (Var (Name "t")) "y")) extendedEnv ~?= Just (TableRef "_t0" (StringVal "y")),
         S.evalState (resolveVar (Dot (Var (Name "t2")) "z")) extendedEnv ~?= Nothing,
         -- and how we refer to the field shouldn't matter
-        S.evalState (resolveVar (Proj (Var (Name "t")) (Val (StringVal "z")))) extendedEnv ~?= Just (TableRef "_t1" (StringVal "z")),
+        S.evalState (resolveVar (Proj (Var (Name "t")) (Val (StringVal "z")))) extendedEnv ~?= Just (TableRef "_t0" (StringVal "z")),
         S.evalState (resolveVar (Proj (Var (Name "t2")) (Val (StringVal "z")))) extendedEnv ~?= Nothing,
         S.evalState (resolveVar (Proj (Val NilVal) (Val (StringVal "z")))) extendedEnv ~?= Nothing
       ]
@@ -105,8 +105,8 @@ test_evaluateLen =
   "evaluate len" ~:
     TestList
       [ evaluate (Op1 Len (Val (StringVal "5520"))) extendedEnv ~?= IntVal 4,
-        evaluate (Op1 Len (Val (TableVal "_G"))) extendedEnv ~?= IntVal 2,
-        evaluate (Op1 Len (Val (TableVal "_t1"))) extendedEnv ~?= IntVal 2,
+        evaluate (Op1 Len (Val (TableVal "_G"))) extendedEnv ~?= NilVal,
+        evaluate (Op1 Len (Val (TableVal "_t0"))) extendedEnv ~?= IntVal 2,
         evaluate (Op1 Len (Val (TableVal "_t550"))) extendedEnv ~?= NilVal,
         evaluate (Op1 Len (Val (IntVal 5520))) extendedEnv ~?= IntVal 5520,
         evaluate (Op1 Len (Val (BoolVal True))) extendedEnv ~?= IntVal 1
@@ -121,35 +121,35 @@ test_tableConst =
           initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
-                    ("_t1", Map.fromList [(StringVal "x", IntVal 3)])
+                    ("_t0", Map.fromList [(StringVal "x", IntVal 3)])
                   ],
         toStore (S.execState
           (evalE (TableConst [FieldName "x" (Val (IntVal 3)), FieldName "y" (Val (IntVal 5))]))
           initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
-                    ("_t1", Map.fromList [(StringVal "x", IntVal 3), (StringVal "y", IntVal 5)])
+                    ("_t0", Map.fromList [(StringVal "x", IntVal 3), (StringVal "y", IntVal 5)])
                   ],
         toStore (S.execState
           (evalE (TableConst [FieldKey (Val (StringVal "x")) (Val (IntVal 3))]))
           initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
-                    ("_t1", Map.fromList [(StringVal "x", IntVal 3)])
+                    ("_t0", Map.fromList [(StringVal "x", IntVal 3)])
                   ],
         toStore (S.execState
           (evalE (TableConst [FieldKey (Val (StringVal "x")) (Val (IntVal 3)), FieldName "y" (Val (IntVal 5))]))
           initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
-                    ("_t1", Map.fromList [(StringVal "x", IntVal 3), (StringVal "y", IntVal 5)])
+                    ("_t0", Map.fromList [(StringVal "x", IntVal 3), (StringVal "y", IntVal 5)])
                   ],
         toStore (S.execState
           (evalE (TableConst []))
           initialEnv)
           ~?= Map.fromList
                   [ ("_G", Map.empty),
-                    ("_t1", Map.empty)
+                    ("_t0", Map.empty)
                   ]
       ]
 
@@ -246,14 +246,14 @@ tExecTable =
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList
-              [ (StringVal "a", TableVal "_t1"),
+              [ (StringVal "a", TableVal "_t0"),
                 (StringVal "k", IntVal 20),
                 (StringVal "o1", IntVal 10),
                 (StringVal "o2", StringVal "great"),
                 (StringVal "o3", IntVal 11)
               ]
           ),
-          ("_t1", Map.fromList [(IntVal 20, StringVal "great"), (StringVal "x", IntVal 11)])
+          ("_t0", Map.fromList [(IntVal 20, StringVal "great"), (StringVal "x", IntVal 11)])
         ]
 
 tExecBfs :: Test

--- a/test/LuEvaluatorTest.hs
+++ b/test/LuEvaluatorTest.hs
@@ -41,17 +41,17 @@ test_index =
   "index tests" ~:
     TestList
       [ -- The global variable "x" is unitialized (i.e. not present in the initial store)
-        S.evalState (index xref) initialEnv ~?= NilVal,
+        S.evalState (C.index xref) initialEnv ~?= NilVal,
         -- But there is a value for "x" available in the extended store
-        S.evalState (index xref) extendedEnv ~?= IntVal 3,
+        S.evalState (C.index xref) extendedEnv ~?= IntVal 3,
         -- If a table name is not found in the store, accessing its reference also returns nil.
-        S.evalState (index yref) initialEnv ~?= NilVal,
+        S.evalState (C.index yref) initialEnv ~?= NilVal,
         -- We should also be able to access "t[1]" in the extended store
-        S.evalState (index yref) extendedEnv ~?= BoolVal True,
-        S.evalState (index (TableRef "z" NilVal)) extendedEnv ~?= NilVal,
+        S.evalState (C.index yref) extendedEnv ~?= BoolVal True,
+        S.evalState (C.index (TableRef "z" NilVal)) extendedEnv ~?= NilVal,
         -- Updates using the `nil` key are ignored
         toStore (S.execState (C.update (TableRef "_t" NilVal) (IntVal 3)) extendedEnv) ~?= toStore extendedEnv,
-        S.evalState (index (GlobalRef "t")) extendedEnv ~?= TableVal "_t1"
+        S.evalState (C.index (GlobalRef "t")) extendedEnv ~?= TableVal "_t1"
       ]
 
 test_update :: Test
@@ -59,13 +59,13 @@ test_update =
   "index tests" ~:
     TestList
       [ -- If we assign to x, then we can find its new value
-        S.evalState (C.update xref (IntVal 4) >> index xref) initialEnv ~?= IntVal 4,
+        S.evalState (C.update xref (IntVal 4) >> C.index xref) initialEnv ~?= IntVal 4,
         -- If we assign to x, then remove it, we cannot find it anymore
-        S.evalState (C.update xref (IntVal 4) >> C.update xref NilVal >> index xref) initialEnv ~?= NilVal,
+        S.evalState (C.update xref (IntVal 4) >> C.update xref NilVal >> C.index xref) initialEnv ~?= NilVal,
         -- If we assign to t.y, then we can find its new value
-        S.evalState (C.update yref (IntVal 5) >> index yref) extendedEnv ~?= IntVal 5,
+        S.evalState (C.update yref (IntVal 5) >> C.index yref) extendedEnv ~?= IntVal 5,
         -- If we assign nil to t.y, then we cannot find it
-        S.evalState (C.update yref NilVal >> index yref) extendedEnv ~?= NilVal
+        S.evalState (C.update yref NilVal >> C.index yref) extendedEnv ~?= NilVal
       ]
 
 test_resolveVar :: Test

--- a/test/LuStepperTest.hs
+++ b/test/LuStepperTest.hs
@@ -59,14 +59,14 @@ tExecStepTable =
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList
-              [ (StringVal "a", TableVal "_t1"),
+              [ (StringVal "a", TableVal "_t0"),
                 (StringVal "k", IntVal 20),
                 (StringVal "o1", IntVal 10),
                 (StringVal "o2", StringVal "great"),
                 (StringVal "o3", IntVal 11)
               ]
           ),
-          ("_t1", Map.fromList [(IntVal 20, StringVal "great"), (StringVal "x", IntVal 11)])
+          ("_t0", Map.fromList [(IntVal 20, StringVal "great"), (StringVal "x", IntVal 11)])
         ]
 
 -- | bfs.lu: calculate breadth-first search of a graph represented by adjacency lists.

--- a/test/LuStepperTest.hs
+++ b/test/LuStepperTest.hs
@@ -2,7 +2,7 @@ module LuStepperTest where
 
 import LuSyntax
 import LuStepper
-import LuEvaluator (EvalEnv, globalTableName, exec, toStore, Store, emptyEvalEnv, fromStore)
+import LuEvaluator (EvalEnv, globalTableName, exec, toStore, Store, fromStore)
 import LuEvaluatorTest (initialEnv, extendedEnv)
 import State (State)
 import State qualified as S

--- a/test/LuStepperTest.hs
+++ b/test/LuStepperTest.hs
@@ -2,7 +2,8 @@ module LuStepperTest where
 
 import LuSyntax
 import LuStepper
-import LuEvaluator (EvalEnv, initialEnv, extendedEnv, globalTableName, exec, toStore, Store, emptyEvalEnv, fromStore)
+import LuEvaluator (EvalEnv, globalTableName, exec, toStore, Store, emptyEvalEnv, fromStore)
+import LuEvaluatorTest (initialEnv, extendedEnv)
 import State (State)
 import State qualified as S
 import Data.Map (Map, (!?))

--- a/test/LuTypeCheckerTest.hs
+++ b/test/LuTypeCheckerTest.hs
@@ -4,26 +4,27 @@ import LuTypeChecker
 import LuSyntax
 import LuTypes
 import State qualified as S
+import Context qualified as C
 import Data.Map qualified as Map
 import Test.HUnit (Counts, Test (..), runTestTT, (~:), (~?=))
 import Test.QuickCheck qualified as QC
 import LuEvaluator (Store)
 
 store :: TypeEnv
-store = setGMap emptyTypeEnv typeMap where 
+store = C.setGMap typeMap emptyTypeEnv where 
   typeMap = Map.fromList
-    [ ("int", IntType),
-      ("string", StringType),
-      ("boolean", BooleanType),
-      ("int-or-string", UnionType IntType StringType), 
-      ("table1", TableType StringType BooleanType),
-      ("table2", TableType StringType IntType),
-      ("table3", TableType BooleanType BooleanType),
-      ("function0", FunctionType Never StringType),
-      ("function1", FunctionType IntType StringType),
-      ("function2", FunctionType StringType StringType),
-      ("function3", FunctionType IntType IntType),
-      ("function4", FunctionType IntType (UnionType IntType StringType))
+    [ (StringVal "int", IntType),
+      (StringVal "string", StringType),
+      (StringVal "boolean", BooleanType),
+      (StringVal "int-or-string", UnionType IntType StringType), 
+      (StringVal "table1", TableType StringType BooleanType),
+      (StringVal "table2", TableType StringType IntType),
+      (StringVal "table3", TableType BooleanType BooleanType),
+      (StringVal "function0", FunctionType Never StringType),
+      (StringVal "function1", FunctionType IntType StringType),
+      (StringVal "function2", FunctionType StringType StringType),
+      (StringVal "function3", FunctionType IntType IntType),
+      (StringVal "function4", FunctionType IntType (UnionType IntType StringType))
     ]
 
 {-

--- a/test/lu/unionReturn.lu
+++ b/test/lu/unionReturn.lu
@@ -1,0 +1,13 @@
+function foo(x : int) : string | int 
+    if x > 5 then 
+        return "here"
+    else 
+        return 1 
+    end 
+end 
+
+z = foo(10)
+z2 = foo(4)
+
+result = z == z2
+


### PR DESCRIPTION
## Work Done 
- Problem: Evaluator and TypeChecker doing duplicate work in managing `environment`. 
- Solution: Factor out common functionality into `Environment` type class. 
- Also, generalize notion of reference so that we can implement local variables in evaluator (should be easy after this change). 