### PR TITLE
refactor: clean up E2E and reduce duplicate code. 

### DIFF
--- a/src/Context.hs
+++ b/src/Context.hs
@@ -1,111 +1,124 @@
-module Context where 
+module Context where
 
 import Data.Map (Map)
 import Data.Map qualified as Map
+import LuSyntax
+import LuTypes
 import Stack (Stack)
 import Stack qualified
-import LuTypes 
-import LuSyntax 
 import State (State)
-import qualified State as S
+import State qualified as S
 
-data Context a = Context {
-    gMap :: Map Value a, 
-    localStack :: Stack (LocalVar a),  
+data Context a = Context
+  { gMap :: Map Value a,
+    localStack :: Stack (LocalVar a),
     curDepth :: Int
-}
+  }
 
-data Reference = 
-    GlobalRef Name -- name of global
-  | LocalRef Name  -- name of local
-  | TableRef Name Value  -- name of table, value that keys it. 
+data Reference
+  = GlobalRef Name -- name of global
+  | LocalRef Name -- name of local
+  | TableRef Name Value -- name of table, value that keys it.
   deriving (Eq, Show)
 
-data LocalVar a = LocalVar {
-    val :: a,
+data LocalVar a = LocalVar
+  { val :: a,
     name :: Name,
     depth :: Int
-}
+  }
 
-class ExtendedContext ce where 
-    emptyContext :: ce 
-    exitScope :: ce -> ce 
-    enterScope :: ce -> ce 
+class ExtendedContext ce where
+  emptyContext :: ce
+  exitScope :: ce -> ce
+  enterScope :: ce -> ce
 
-class Environment a v where 
-    getContext :: a -> Context v 
-    setContext :: a -> Context v -> a 
+class (Eq v) => Environment a v where
+  getContext :: a -> Context v
+  setContext :: a -> Context v -> a
 
-    index :: Reference -> State a v 
+  index :: Reference -> State a v
 
-    indexTable :: (Name, Value) -> v -> State a v
+  indexTable :: (Name, Value) -> v -> State a v
 
-    updateTable :: (Name, Value) -> v -> State a () 
+  updateTable :: (Name, Value) -> v -> State a ()
 
-    indexWithDefault :: Reference -> v -> State a v 
-    indexWithDefault (GlobalRef n) d = do 
-        env <- S.get 
-        return $ case getGlobal n env of 
-            Just v -> v 
-            _ -> d
-    indexWithDefault (LocalRef n) d = do 
-        env <- S.get 
-        return $ case getLocal n env of 
-            Just v -> v 
-            _ -> d 
-    indexWithDefault (TableRef tname tkey) d = indexTable (tname, tkey) d
+  lookup :: Name -> State a v
 
-    update :: Reference -> v -> State a ()
-    update (GlobalRef n) v = S.modify (addGlobal (n, v)) 
-    update (LocalRef n) v = S.modify (addLocal (n, v))
-    update (TableRef n k) v = updateTable (n, k) v 
+  indexWithDefault :: Reference -> v -> State a v
+  indexWithDefault (GlobalRef n) d = do
+    env <- S.get
+    return $ case getGlobal n env of
+      Just v -> v
+      _ -> d
+  indexWithDefault (LocalRef n) d = do
+    env <- S.get
+    return $ case getLocal n env of
+      Just v -> v
+      _ -> d
+  indexWithDefault (TableRef tname tkey) d = indexTable (tname, tkey) d
 
-    addLocal :: (Name, v) -> a -> a 
-    addLocal (n, v) env = let c = getContext env in
-                          let lv = LocalVar {val = v, name = n, depth = curDepth c} in 
-        setContext env (c {localStack = Stack.push (localStack c) lv}) 
-    
-    addGlobal :: (Name, v) -> a -> a 
-    addGlobal (k, v) env = let c = getContext env in
-        setContext env (c {gMap = Map.insert (StringVal k) v (gMap c)})
+  update :: Reference -> v -> State a ()
+  update (GlobalRef n) v = S.modify (addGlobal (n, v))
+  update (LocalRef n) v = S.modify (addLocal (n, v))
+  update (TableRef n k) v = updateTable (n, k) v
 
-    setGMap :: Map Value v -> a -> a 
-    setGMap m env = let c = getContext env in 
-        setContext env (c {gMap = m})
+  addLocal :: (Name, v) -> a -> a
+  addLocal (n, v) env =
+    let c = getContext env
+     in let lv = LocalVar {val = v, name = n, depth = curDepth c}
+         in setContext env (c {localStack = Stack.push (localStack c) lv})
 
-    getGlobal :: Name -> a -> Maybe v 
-    getGlobal n env = Map.lookup (StringVal n) ((gMap . getContext) env)
+  addGlobal :: (Name, v) -> a -> a
+  addGlobal (k, v) env =
+    let c = getContext env
+     in setContext env (c {gMap = Map.insert (StringVal k) v (gMap c)})
 
-    getLocal :: Name -> a -> Maybe v 
-    getLocal n env = case Stack.peekUntil ((localStack . getContext) env) (\lv -> name lv == n) of 
-        Just lv -> Just $ val lv 
-        _ -> Nothing
+  setGMap :: Map Value v -> a -> a
+  setGMap m env =
+    let c = getContext env
+     in setContext env (c {gMap = m})
 
-    prepareFunctionEnv :: [(Name, v)] -> State a ()
-    prepareFunctionEnv params = do 
-        let getThisContext = getContext :: a -> Context v
-        S.modify (\env -> setContext env (enterScope (getThisContext env)))
-        S.modify (\e -> foldr addLocal e params)
-    
-instance ExtendedContext (Context a) where 
-    emptyContext :: Context a 
-    emptyContext = Context {gMap = Map.empty, localStack = Stack.empty, curDepth = 0}
+  getGlobal :: Name -> a -> Maybe v
+  getGlobal n env = Map.lookup (StringVal n) ((gMap . getContext) env)
 
-    -- | Decrease depth of scope and remove variables at this level. 
-    exitScope :: Context a -> Context a
-    exitScope c = c {localStack = Stack.popUntil (localStack c) (aboveDepth (curDepth c)), curDepth = curDepth c - 1} where 
-        aboveDepth :: Int -> LocalVar a -> Bool 
-        aboveDepth n lv = depth lv < curDepth c
+  getLocal :: Name -> a -> Maybe v
+  getLocal n env = case Stack.peekUntil ((localStack . getContext) env) (\lv -> name lv == n) of
+    Just lv -> Just $ val lv
+    _ -> Nothing
 
-    -- | Increase depth of scope. 
-    enterScope :: Context a -> Context a
-    enterScope c = c {curDepth = curDepth c + 1}
+  lookupWithUnknown :: v -> Name -> State a v
+  lookupWithUnknown unknown n = do
+    localResolve <- index (LocalRef n)
+    globalResolve <- index (GlobalRef n)
+    if localResolve == unknown
+      then return globalResolve
+      else return localResolve
 
-instance Show a => Show (LocalVar a) where 
-    show :: LocalVar a -> String 
-    show lv = show (name lv) ++ "=" ++ show (val lv) ++ ":" ++ show (depth lv)
+  prepareFunctionEnv :: [(Name, v)] -> State a ()
+  prepareFunctionEnv params = do
+    let getThisContext = getContext :: a -> Context v
+    S.modify (\env -> setContext env (enterScope (getThisContext env)))
+    S.modify (\e -> foldr addLocal e params)
 
-instance Show a => Show (Context a) where 
-    show :: Context a -> String 
-    show env = show (gMap env) ++ "\n" ++ show (localStack env) ++ "\n" ++ "[depth=" ++ show (curDepth env) ++ "]"
-    
+instance ExtendedContext (Context a) where
+  emptyContext :: Context a
+  emptyContext = Context {gMap = Map.empty, localStack = Stack.empty, curDepth = 0}
+
+  -- \| Decrease depth of scope and remove variables at this level.
+  exitScope :: Context a -> Context a
+  exitScope c = c {localStack = Stack.popUntil (localStack c) (aboveDepth (curDepth c)), curDepth = curDepth c - 1}
+    where
+      aboveDepth :: Int -> LocalVar a -> Bool
+      aboveDepth n lv = depth lv < curDepth c
+
+  -- \| Increase depth of scope.
+  enterScope :: Context a -> Context a
+  enterScope c = c {curDepth = curDepth c + 1}
+
+instance (Show a) => Show (LocalVar a) where
+  show :: LocalVar a -> String
+  show lv = show (name lv) ++ "=" ++ show (val lv) ++ ":" ++ show (depth lv)
+
+instance (Show a) => Show (Context a) where
+  show :: Context a -> String
+  show env = show (gMap env) ++ "\n" ++ show (localStack env) ++ "\n" ++ "[depth=" ++ show (curDepth env) ++ "]"

--- a/src/LuEvaluator.hs
+++ b/src/LuEvaluator.hs
@@ -1,5 +1,7 @@
 module LuEvaluator where
 
+import Context (Context, Environment, ExtendedContext, Reference (GlobalRef, LocalRef, TableRef))
+import Context qualified as C
 import Control.Monad (when)
 import Data.List qualified as List
 import Data.Map (Map, (!?))
@@ -7,8 +9,6 @@ import Data.Map qualified as Map
 import LuParser qualified
 import LuSyntax
 import LuTypes
-import Context (Context, Environment, Reference (LocalRef, GlobalRef, TableRef), ExtendedContext)
-import Context qualified as C
 import State (State)
 import State qualified as S
 import Test.HUnit (Counts, Test (..), runTestTT, (~:), (~?=))
@@ -18,57 +18,62 @@ type Store = Map Name Table
 
 type Table = Map Value Value
 
-data EvalEnv = EvalEnv { 
-  context :: Context Value,
-  tableMap :: Map Name Table
-} deriving Show
+data EvalEnv = EvalEnv
+  { context :: Context Value,
+    tableMap :: Map Name Table
+  }
+  deriving (Show)
 
-instance ExtendedContext EvalEnv where 
+instance ExtendedContext EvalEnv where
   emptyContext :: EvalEnv
   emptyContext = EvalEnv {context = C.emptyContext, tableMap = Map.empty}
 
-  exitScope :: EvalEnv -> EvalEnv 
+  exitScope :: EvalEnv -> EvalEnv
   exitScope env = env {context = C.exitScope (context env)}
 
-  enterScope :: EvalEnv -> EvalEnv 
+  enterScope :: EvalEnv -> EvalEnv
   enterScope env = env {context = C.enterScope (context env)}
 
-instance Environment EvalEnv Value where 
-  getContext :: EvalEnv -> Context Value 
-  getContext = context 
+instance Environment EvalEnv Value where
+  getContext :: EvalEnv -> Context Value
+  getContext = context
 
-  setContext :: EvalEnv -> Context Value -> EvalEnv 
+  setContext :: EvalEnv -> Context Value -> EvalEnv
   setContext env c = env {context = c}
-  
-  index :: Reference -> State EvalEnv Value 
-  index r = C.indexWithDefault r NilVal 
+
+  index :: Reference -> State EvalEnv Value
+  index r = C.indexWithDefault r NilVal
+
+  lookup :: Name -> State EvalEnv Value
+  lookup = C.lookupWithUnknown NilVal
 
   indexTable :: (Name, Value) -> Value -> State EvalEnv Value
-  indexTable (tname, tkey) d = do 
-    env <- S.get 
-    return $ case Map.lookup tname (tableMap env) of 
-      Just table -> case Map.lookup tkey table of 
-        Just v -> v 
-        _ -> d 
+  indexTable (tname, tkey) d = do
+    env <- S.get
+    return $ case Map.lookup tname (tableMap env) of
+      Just table -> case Map.lookup tkey table of
+        Just v -> v
+        _ -> d
       _ -> d
-  
+
   updateTable :: (Name, Value) -> Value -> State EvalEnv ()
-  updateTable (tname, tkey) v = do 
+  updateTable (tname, tkey) v = do
     mTable <- tableFromState tname
-    S.modify (updateTableHelper mTable) where 
-      updateTableHelper :: Maybe Table -> EvalEnv -> EvalEnv 
-      updateTableHelper mt env = case mt of 
-        Nothing -> env 
+    S.modify (updateTableHelper mTable)
+    where
+      updateTableHelper :: Maybe Table -> EvalEnv -> EvalEnv
+      updateTableHelper mt env = case mt of
+        Nothing -> env
         Just t -> env {tableMap = Map.insert tname (Map.insert tkey v t) (tableMap env)}
 
 resolveVar :: Var -> State EvalEnv (Maybe Reference)
-resolveVar (Name n) = do 
+resolveVar (Name n) = do
   env <- S.get
-  let localLookup = C.getLocal n env :: Maybe Value 
-  let globalLookup = C.getGlobal n env :: Maybe Value 
-  return $ case (localLookup, globalLookup) of 
-        (Just v, _) -> Just $ LocalRef n
-        _ -> Just $ GlobalRef n
+  let localLookup = C.getLocal n env :: Maybe Value
+  let globalLookup = C.getGlobal n env :: Maybe Value
+  return $ case (localLookup, globalLookup) of
+    (Just v, _) -> Just $ LocalRef n
+    _ -> Just $ GlobalRef n
 resolveVar (Dot exp n) = do
   e <- evalE exp
   return $ case e of
@@ -87,31 +92,33 @@ toStore :: EvalEnv -> Store
 toStore env = Map.insert globalTableName (C.gMap (context env)) (tableMap env)
 
 -- | Helper function to convert Store to evaluation environment (for testing and debugging)
-fromStore :: Store -> EvalEnv 
-fromStore s = case Map.lookup globalTableName s of 
-  Nothing -> C.emptyContext -- Shouldn't hit this cae.  
-  Just globalTable -> newEnv where 
-    newEnv = let initEnv = C.emptyContext in 
-      (C.setGMap globalTable initEnv) {tableMap = newTables} 
-        where 
+fromStore :: Store -> EvalEnv
+fromStore s = case Map.lookup globalTableName s of
+  Nothing -> C.emptyContext -- Shouldn't hit this cae.
+  Just globalTable -> newEnv
+    where
+      newEnv =
+        let initEnv = C.emptyContext
+         in (C.setGMap globalTable initEnv) {tableMap = newTables}
+        where
           newTables = Map.filterWithKey (\k _ -> k /= globalTableName) s
 
-instance PP EvalEnv where 
-  pp env = undefined 
+instance PP EvalEnv where
+  pp env = undefined
 
 globalTableName :: Name
 globalTableName = "_G"
 
-returnValueName :: Name 
+returnValueName :: Name
 returnValueName = "@R"
 
-returnFlagName :: Name 
+returnFlagName :: Name
 returnFlagName = "@F"
 
-haltFlagName :: Name 
+haltFlagName :: Name
 haltFlagName = "@H"
 
-errorCodeName :: Name 
+errorCodeName :: Name
 errorCodeName = "@E"
 
 returnValueRef :: Reference
@@ -120,54 +127,54 @@ returnValueRef = GlobalRef returnValueName
 returnFlagRef :: Reference
 returnFlagRef = GlobalRef returnFlagName
 
-haltFlagRef :: Reference 
+haltFlagRef :: Reference
 haltFlagRef = GlobalRef haltFlagName
 
-errorCodeRef :: Reference 
+errorCodeRef :: Reference
 errorCodeRef = GlobalRef errorCodeName
 
-throwError :: ErrorCode -> State EvalEnv () 
-throwError ec = C.update errorCodeRef (ErrorVal ec) >> C.update haltFlagRef (BoolVal True) 
+throwError :: ErrorCode -> State EvalEnv ()
+throwError ec = C.update errorCodeRef (ErrorVal ec) >> C.update haltFlagRef (BoolVal True)
 
-didReturnOrHalt :: State EvalEnv Bool 
-didReturnOrHalt = do 
-  didReturn <- isReturnFlagSet 
-  didHalt <- isHaltFlagSet 
+didReturnOrHalt :: State EvalEnv Bool
+didReturnOrHalt = do
+  didReturn <- isReturnFlagSet
+  didHalt <- isHaltFlagSet
   return $ didReturn || didHalt
 
 -- | Check if we should terminate, if so return stopCase otherwise continue with eval
-continueWithFlags :: a -> State EvalEnv a -> State EvalEnv a 
-continueWithFlags stopCase continue = do 
+continueWithFlags :: a -> State EvalEnv a -> State EvalEnv a
+continueWithFlags stopCase continue = do
   shouldStop <- didReturnOrHalt
   if shouldStop then return stopCase else continue
 
-isError :: Value -> Bool 
-isError (ErrorVal _) = True 
-isError _ = False 
+isError :: Value -> Bool
+isError (ErrorVal _) = True
+isError _ = False
 
-didError :: EvalEnv -> Bool 
-didError env = 
+didError :: EvalEnv -> Bool
+didError env =
   case S.evalState (C.index haltFlagRef) env of
     (BoolVal True) -> True
     _ -> False
 
-getError :: EvalEnv -> ErrorCode 
-getError env = 
-  case S.evalState (C.index errorCodeRef) env of 
-    (ErrorVal e) -> e 
+getError :: EvalEnv -> ErrorCode
+getError env =
+  case S.evalState (C.index errorCodeRef) env of
+    (ErrorVal e) -> e
     _ -> UnknownError
 
-isFlagSet :: Name -> State EvalEnv Bool 
-isFlagSet n = do 
+isFlagSet :: Name -> State EvalEnv Bool
+isFlagSet n = do
   value <- evalE (Var (Name n))
-  return $ case value of 
-    (BoolVal True) -> True 
+  return $ case value of
+    (BoolVal True) -> True
     _ -> False
 
-isReturnFlagSet :: State EvalEnv Bool 
+isReturnFlagSet :: State EvalEnv Bool
 isReturnFlagSet = isFlagSet returnFlagName
 
-isHaltFlagSet :: State EvalEnv Bool 
+isHaltFlagSet :: State EvalEnv Bool
 isHaltFlagSet = isFlagSet haltFlagName
 
 tableFromState :: Name -> State EvalEnv (Maybe Table)
@@ -191,12 +198,12 @@ nonNil (k, v) = k /= NilVal && v /= NilVal
 
 -- | Expression evaluator
 evalE :: Expression -> State EvalEnv Value
-evalE e = do 
+evalE e = do
   v <- doEvalE e
-  case v of 
+  case v of
     (ErrorVal ec) -> throwError ec >> return v
     _ -> return v
-  where 
+  where
     doEvalE (Var v) = do
       mr <- resolveVar v -- see above
       case mr of
@@ -209,42 +216,42 @@ evalE e = do
       e' <- evalE e
       evalOp1 o e'
     doEvalE (TableConst _fs) = evalTableConst _fs
-    doEvalE (Call func pps) = do 
-      fv <- evalE (Var func) 
-      case fv of 
-        (FunctionVal ps rt b) -> do 
+    doEvalE (Call func pps) = do
+      fv <- evalE (Var func)
+      case fv of
+        (FunctionVal ps rt b) -> do
           parameters <- evalParameters (map fst ps) pps
           let extParameters = (returnValueName, NilVal) : (returnFlagName, BoolVal False) : parameters
-          C.prepareFunctionEnv extParameters 
-          eval b 
-          returnValue <- evalE (Var (Name returnValueName)) 
+          C.prepareFunctionEnv extParameters
+          eval b
+          returnValue <- evalE (Var (Name returnValueName))
           S.modify C.exitScope
           return returnValue
         _ -> return NilVal
 
 evalParameters :: [Name] -> [Expression] -> State EvalEnv [(Name, Value)]
-evalParameters pNames pExps = do 
-  pValues <- seqEval pExps 
+evalParameters pNames pExps = do
+  pValues <- seqEval pExps
   return $ zip pNames pValues
 
--- | Set list of parameters to list of expressions, return resulting state. 
-setVars :: [Name] -> [Expression] -> State EvalEnv () 
-setVars pNames pps = do 
+-- | Set list of parameters to list of expressions, return resulting state.
+setVars :: [Name] -> [Expression] -> State EvalEnv ()
+setVars pNames pps = do
   values <- seqEval pps
   foldr seqSet (return ()) (zip values pNames)
-  where 
-    seqSet :: (Value, Name) -> State EvalEnv () -> State EvalEnv () 
+  where
+    seqSet :: (Value, Name) -> State EvalEnv () -> State EvalEnv ()
     seqSet p@(v, n) s = s >> evalS (Assign (Name n, UnknownType) (Val v))
-    
 
--- | Evaluate a list of expressions in sequence (passing state along right to left), returning all values in final state monad. 
+-- | Evaluate a list of expressions in sequence (passing state along right to left), returning all values in final state monad.
 seqEval :: [Expression] -> State EvalEnv [Value]
-seqEval = foldr seqEvalHelper (return []) where 
-  seqEvalHelper :: Expression -> State EvalEnv [Value] -> State EvalEnv [Value]
-  seqEvalHelper e s = do 
-    curValues <- s
-    newValue <- evalE e 
-    return (newValue : curValues)
+seqEval = foldr seqEvalHelper (return [])
+  where
+    seqEvalHelper :: Expression -> State EvalEnv [Value] -> State EvalEnv [Value]
+    seqEvalHelper e s = do
+      curValues <- s
+      newValue <- evalE e
+      return (newValue : curValues)
 
 fieldToPair :: TableField -> State EvalEnv (Value, Value)
 fieldToPair (FieldName n exp) = do
@@ -270,9 +277,9 @@ evalTableConst xs = do
     helper = foldr accuFieldToPair (return [])
 
 getTableSize :: String -> State EvalEnv (Maybe Int)
-getTableSize v = do 
-  s <- S.get 
-  return $ case Map.lookup v (tableMap s) of 
+getTableSize v = do
+  s <- S.get
+  return $ case Map.lookup v (tableMap s) of
     Just t -> Just $ length t
     _ -> Nothing
 
@@ -321,33 +328,33 @@ eval (Block ss) = mapM_ evalS ss
 
 -- | Statement evaluator
 evalS :: Statement -> State EvalEnv ()
-evalS s = continueWithFlags () (doEvalS s) where 
-  doEvalS (If e s1 s2) = do
-    v <- evalE e
-    if toBool v then eval s1 else eval s2
-  doEvalS w@(While e ss) = do
-    v <- evalE e
-    when (toBool v) $ do
-      eval ss
-      evalS w
-  doEvalS (Assign (v, _) e) = do
-    -- update global variable or table field v to value of e
-    mRef <- resolveVar v
-    e' <- evalE e
-    case mRef of
-      Just ref -> C.update ref e'
-      _ -> return ()
-  doEvalS s@(Repeat b e) = evalS (While (Op1 Not e) b) -- keep evaluating block b until expression e is true
-  doEvalS (Return e) = evalS (Assign (Name returnValueName, UnknownType) e) >> evalS (Assign (Name returnFlagName, BooleanType) (Val (BoolVal True)))
-  doEvalS Empty = return () -- do nothing
+evalS s = continueWithFlags () (doEvalS s)
+  where
+    doEvalS (If e s1 s2) = do
+      v <- evalE e
+      if toBool v then eval s1 else eval s2
+    doEvalS w@(While e ss) = do
+      v <- evalE e
+      when (toBool v) $ do
+        eval ss
+        evalS w
+    doEvalS (Assign (v, _) e) = do
+      -- update global variable or table field v to value of e
+      mRef <- resolveVar v
+      e' <- evalE e
+      case mRef of
+        Just ref -> C.update ref e'
+        _ -> return ()
+    doEvalS s@(Repeat b e) = evalS (While (Op1 Not e) b) -- keep evaluating block b until expression e is true
+    doEvalS (Return e) = evalS (Assign (Name returnValueName, UnknownType) e) >> evalS (Assign (Name returnFlagName, BooleanType) (Val (BoolVal True)))
+    doEvalS Empty = return () -- do nothing
 
-execWithoutError :: Block -> EvalEnv -> EvalEnv 
+execWithoutError :: Block -> EvalEnv -> EvalEnv
 execWithoutError = S.execState . eval
 
 exec :: Block -> EvalEnv -> Either String EvalEnv
-exec b env = let finalEnv = S.execState (eval b) env in
-  if didError finalEnv then 
-    Left $ (show . getError) finalEnv
-  else 
-    return finalEnv
-
+exec b env =
+  let finalEnv = S.execState (eval b) env
+   in if didError finalEnv
+        then Left $ (show . getError) finalEnv
+        else return finalEnv

--- a/src/LuStepper.hs
+++ b/src/LuStepper.hs
@@ -125,7 +125,7 @@ stepper = go initialStepper
         Just (":q", _) -> return ()
         -- run current block to completion
         Just (":r", _) ->
-          let s' = exec (block ss) (env ss)
+          let s' = execWithoutError (block ss) (env ss)
            in go ss {block = mempty, env = s', history = Just ss}
         -- next statement (could be multiple)
         Just (":n", strs) -> do

--- a/src/LuSyntax.hs
+++ b/src/LuSyntax.hs
@@ -53,7 +53,7 @@ data Value
   | ErrorVal ErrorCode
   deriving (Eq, Show)
 
-data ErrorCode = IllegalArguments | DivideByZero deriving (Eq, Show, Enum)
+data ErrorCode = IllegalArguments | DivideByZero | UnknownError deriving (Eq, Show, Enum)
 
 type Parameter = (Name, LType) 
   

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -165,11 +165,11 @@ isPolymorphicBop Lt = True
 isPolymorphicBop Le = True 
 isPolymorphicBop _ = False 
 
-typeCheckAST :: Block -> Either String () 
-typeCheckAST b = S.evalState (typeCheckBlock b) emptyTypeEnv
+typeCheckAST :: Block -> TypeEnv -> Either String () 
+typeCheckAST b = S.evalState (typeCheckBlock b)
 
-runForEnv :: Block -> Either String TypeEnv 
-runForEnv b = case S.runState (typeCheckBlock b) emptyTypeEnv of 
+runForEnv :: Block -> TypeEnv -> Either String TypeEnv 
+runForEnv b env = case S.runState (typeCheckBlock b) env of 
     (Right (), finalStore) -> Right finalStore
     (Left l, finalStore) -> Left l
     

--- a/src/LuTypeChecker.hs
+++ b/src/LuTypeChecker.hs
@@ -1,371 +1,372 @@
 module LuTypeChecker where
 
+import Context (Context, Environment, ExtendedContext, Reference (GlobalRef, LocalRef, TableRef))
+import Context qualified as C
 import Control.Monad
-import LuSyntax
-import State (State)
-import qualified State as S
-import Data.Map (Map)
 import Data.List (nub)
-import qualified Data.Map as Map
-import qualified Stack
-import Context (Context, Reference (GlobalRef, LocalRef, TableRef), Environment, ExtendedContext)
-import qualified Context as C
-import LuTypes 
+import Data.Map (Map)
+import Data.Map qualified as Map
+import LuSyntax
+import LuTypes
+import Stack qualified
+import State (State)
+import State qualified as S
 
-returnTypeName :: Name 
+returnTypeName :: Name
 returnTypeName = "@R"
 
-data TypeEnv = TypeEnv {
-    uncalledFuncs :: Map Name Value, 
+data TypeEnv = TypeEnv
+  { uncalledFuncs :: Map Name Value,
     context :: Context LType
-} deriving Show 
+  }
+  deriving (Show)
 
-instance ExtendedContext TypeEnv where 
-    emptyContext :: TypeEnv 
-    emptyContext = TypeEnv {context = C.emptyContext, uncalledFuncs = Map.empty}
+instance ExtendedContext TypeEnv where
+  emptyContext :: TypeEnv
+  emptyContext = TypeEnv {context = C.emptyContext, uncalledFuncs = Map.empty}
 
-    enterScope :: TypeEnv -> TypeEnv 
-    enterScope env = env {context = C.enterScope (context env)}
+  enterScope :: TypeEnv -> TypeEnv
+  enterScope env = env {context = C.enterScope (context env)}
 
-    exitScope :: TypeEnv -> TypeEnv 
-    exitScope env = env {context = C.exitScope (context env)}
+  exitScope :: TypeEnv -> TypeEnv
+  exitScope env = env {context = C.exitScope (context env)}
 
-instance Environment TypeEnv LType where 
-    getContext :: TypeEnv -> Context LType 
-    getContext = context 
+instance Environment TypeEnv LType where
+  getContext :: TypeEnv -> Context LType
+  getContext = context
 
-    setContext :: TypeEnv -> Context LType -> TypeEnv 
-    setContext env newContext = env {context = newContext}
+  setContext :: TypeEnv -> Context LType -> TypeEnv
+  setContext env newContext = env {context = newContext}
 
-    index :: Reference -> State TypeEnv LType 
-    index r@(GlobalRef _) = C.indexWithDefault r NilType  
-    index r@(LocalRef _) = C.indexWithDefault r UnknownType
-    index r = C.indexWithDefault r NilType
+  index :: Reference -> State TypeEnv LType
+  index r@(GlobalRef _) = C.indexWithDefault r NilType
+  index r@(LocalRef _) = C.indexWithDefault r UnknownType
+  index r = C.indexWithDefault r NilType
 
-    indexTable :: (Name, Value) -> LType -> State TypeEnv LType
-    indexTable _ = return
+  indexTable :: (Name, Value) -> LType -> State TypeEnv LType
+  indexTable _ = return
 
-    updateTable :: (Name, Value) -> LType -> State TypeEnv ()
-    updateTable _ _ = return ()
+  updateTable :: (Name, Value) -> LType -> State TypeEnv ()
+  updateTable _ _ = return ()
 
-contextLookup :: Name -> State TypeEnv LType 
-contextLookup n = do 
-    localResolve <- C.index (LocalRef n)
-    globalResolve <- C.index (GlobalRef n)
-    if localResolve == UnknownType then 
-        return globalResolve
-    else 
-        return localResolve
+  lookup :: Name -> State TypeEnv LType
+  lookup = C.lookupWithUnknown UnknownType
 
-emptyTypeEnv :: TypeEnv 
+emptyTypeEnv :: TypeEnv
 emptyTypeEnv = TypeEnv {context = C.emptyContext, uncalledFuncs = Map.empty}
 
 addUncalledFunc :: (Name, Value) -> TypeEnv -> TypeEnv
 addUncalledFunc (k, v) env = env {uncalledFuncs = Map.insert k v (uncalledFuncs env)}
 
-getUncalledFunc :: TypeEnv -> Name -> Maybe Value 
+getUncalledFunc :: TypeEnv -> Name -> Maybe Value
 getUncalledFunc env n = Map.lookup n (uncalledFuncs env)
 
-removeUncalledFunc :: TypeEnv -> Name -> TypeEnv 
+removeUncalledFunc :: TypeEnv -> Name -> TypeEnv
 removeUncalledFunc env n = env {uncalledFuncs = Map.delete n (uncalledFuncs env)}
 
 type TypecheckerState a = State TypeEnv (Either String a)
 
-class Synthable a where 
-    synth :: a -> TypecheckerState LType
+class Synthable a where
+  synth :: a -> TypecheckerState LType
 
-instance Synthable Uop where 
-    synth Neg = return $ return $ FunctionType IntType IntType
-    synth Not = return $ return $ FunctionType AnyType BooleanType 
-    synth Len = return $ return $ FunctionType (UnionType IntType (UnionType StringType (TableType AnyType AnyType))) IntType  
+instance Synthable Uop where
+  synth Neg = return $ return $ FunctionType IntType IntType
+  synth Not = return $ return $ FunctionType AnyType BooleanType
+  synth Len = return $ return $ FunctionType (UnionType IntType (UnionType StringType (TableType AnyType AnyType))) IntType
 
-instance Synthable Bop where 
-    synth Plus = return $ return $ FunctionType IntType (FunctionType IntType IntType)
-    synth Minus = return $ return $ FunctionType IntType (FunctionType IntType IntType)
-    synth Times = return $ return $ FunctionType IntType (FunctionType IntType IntType)
-    synth Divide = return $ return $ FunctionType IntType (FunctionType IntType IntType)
-    synth Modulo = return $ return $ FunctionType IntType (FunctionType IntType IntType)
-    synth Eq = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
-    synth Gt = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
-    synth Ge = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
-    synth Lt = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
-    synth Le = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
-    synth Concat = return $ return $ FunctionType StringType (FunctionType StringType StringType)
+instance Synthable Bop where
+  synth Plus = return $ return $ FunctionType IntType (FunctionType IntType IntType)
+  synth Minus = return $ return $ FunctionType IntType (FunctionType IntType IntType)
+  synth Times = return $ return $ FunctionType IntType (FunctionType IntType IntType)
+  synth Divide = return $ return $ FunctionType IntType (FunctionType IntType IntType)
+  synth Modulo = return $ return $ FunctionType IntType (FunctionType IntType IntType)
+  synth Eq = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
+  synth Gt = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
+  synth Ge = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
+  synth Lt = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
+  synth Le = return $ return $ FunctionType AnyType (FunctionType AnyType BooleanType)
+  synth Concat = return $ return $ FunctionType StringType (FunctionType StringType StringType)
 
-instance Synthable Value where 
-    synth NilVal = return $ return NilType
-    synth (IntVal _) = return $ return IntType
-    synth (BoolVal _) = return $ return BooleanType 
-    synth (StringVal _) = return $ return StringType 
-    synth (TableVal n) = undefined --what is this case? 
-    synth (FunctionVal pms rt b) = do 
-        C.prepareFunctionEnv ((returnTypeName, rt) : pms)
-        s <- S.get
-        S.modify C.exitScope
-        case S.evalState (typeCheckBlock b) s of 
-            Right () -> do 
-                return $ Right $ synthFunc pms rt
-            Left l -> return $ Left l
+instance Synthable Value where
+  synth NilVal = return $ return NilType
+  synth (IntVal _) = return $ return IntType
+  synth (BoolVal _) = return $ return BooleanType
+  synth (StringVal _) = return $ return StringType
+  synth (TableVal n) = undefined -- what is this case?
+  synth (FunctionVal pms rt b) = do
+    C.prepareFunctionEnv ((returnTypeName, rt) : pms)
+    s <- S.get
+    S.modify C.exitScope
+    case S.evalState (typeCheckBlock b) s of
+      Right () -> do
+        return $ Right $ synthFunc pms rt
+      Left l -> return $ Left l
+  synth (ErrorVal _) = return $ return NilType -- shouldn't hit this case.
 
-synthFunc :: [Parameter] -> LType -> LType 
-synthFunc [] rt = FunctionType Never rt 
+synthFunc :: [Parameter] -> LType -> LType
+synthFunc [] rt = FunctionType Never rt
 synthFunc [(_, t)] rt = FunctionType t rt
 synthFunc ((_, t) : ps) rt = FunctionType t (synthFunc ps rt)
 
-instance Synthable Var where 
-    synth (Name n) = Right <$> contextLookup n
-    synth (Dot exp n) = do 
-        eExpType <- synthesis exp 
-        return $ case eExpType of 
-            Left l -> Left l 
-            Right tExp@(TableType t1 t2) -> case typecheckTableAccess tExp StringType Never of 
-                Right () -> Right t2 
-                Left l -> Left l
-            Right _ -> Left "Cannot access non table type via dot method."
+instance Synthable Var where
+  synth (Name n) = Right <$> C.lookup n
+  synth (Dot exp n) = do
+    eExpType <- synthesis exp
+    return $ case eExpType of
+      Left l -> Left l
+      Right tExp@(TableType t1 t2) -> case typecheckTableAccess tExp StringType Never of
+        Right () -> Right t2
+        Left l -> Left l
+      Right _ -> Left "Cannot access non table type via dot method."
+  synth (Proj tExp kExp) = do
+    eTableType <- synthesis tExp
+    eKeyType <- synthesis kExp
+    return $ case (eTableType, eKeyType) of
+      (Left l, _) -> Left l
+      (_, Left l) -> Left l
+      (Right tableType@(TableType t1 t2), Right keyType) -> case typecheckTableAccess tableType keyType Never of
+        Right () -> Right t2
+        Left l -> Left l
+      _ -> Left "Cannot access not table type via proj method."
 
-    synth (Proj tExp kExp) = do 
-        eTableType <- synthesis tExp 
-        eKeyType <- synthesis kExp 
-        return $ case (eTableType, eKeyType) of 
-            (Left l, _) -> Left l 
-            (_, Left l) -> Left l
-            (Right tableType@(TableType t1 t2), Right keyType) -> case typecheckTableAccess tableType keyType Never of 
-                Right () -> Right t2 
-                Left l -> Left l
-            _ -> Left "Cannot access not table type via proj method."
-
-instance Synthable [TableField] where 
-    synth tfs = do 
-        eTypePairs <- foldr synthTableField (return $ Right []) tfs
-        return $ case eTypePairs of 
-            Left l -> Left l
-            Right typePairs -> do 
-                let (keyTypes, valTypes) = unzip typePairs 
-                Right $ TableType (constructUnionType keyTypes) (constructUnionType valTypes)
-        
-        where 
-
-        synthTableField :: TableField -> TypecheckerState [(LType, LType)] -> TypecheckerState [(LType, LType)]
-        synthTableField (FieldName n e) res = synthTableField (FieldKey (Val (StringVal n)) e) res
-        synthTableField (FieldKey e1 e2) res = do 
-            ePairs <- res
-            eT1 <- synthesis e1 
-            eT2 <- synthesis e2 
-            case (ePairs, eT1, eT2) of 
-                (Right pairs, Right t1, Right t2) -> return $ Right ((t1, t2) : pairs)
-                (Left l, _, _) -> return $ Left l 
-                (_, Left l, _) -> return $ Left l
-                (_, _, Left l) -> return $ Left l
+instance Synthable [TableField] where
+  synth tfs = do
+    eTypePairs <- foldr synthTableField (return $ Right []) tfs
+    return $ case eTypePairs of
+      Left l -> Left l
+      Right typePairs -> do
+        let (keyTypes, valTypes) = unzip typePairs
+        Right $ TableType (constructUnionType keyTypes) (constructUnionType valTypes)
+    where
+      synthTableField :: TableField -> TypecheckerState [(LType, LType)] -> TypecheckerState [(LType, LType)]
+      synthTableField (FieldName n e) res = synthTableField (FieldKey (Val (StringVal n)) e) res
+      synthTableField (FieldKey e1 e2) res = do
+        ePairs <- res
+        eT1 <- synthesis e1
+        eT2 <- synthesis e2
+        case (ePairs, eT1, eT2) of
+          (Right pairs, Right t1, Right t2) -> return $ Right ((t1, t2) : pairs)
+          (Left l, _, _) -> return $ Left l
+          (_, Left l, _) -> return $ Left l
+          (_, _, Left l) -> return $ Left l
 
 isPolymorphicBop :: Bop -> Bool
-isPolymorphicBop Eq = True 
-isPolymorphicBop Gt = True 
-isPolymorphicBop Ge = True 
-isPolymorphicBop Lt = True 
-isPolymorphicBop Le = True 
-isPolymorphicBop _ = False 
+isPolymorphicBop Eq = True
+isPolymorphicBop Gt = True
+isPolymorphicBop Ge = True
+isPolymorphicBop Lt = True
+isPolymorphicBop Le = True
+isPolymorphicBop _ = False
 
-typeCheckAST :: Block -> TypeEnv -> Either String () 
+typeCheckAST :: Block -> TypeEnv -> Either String ()
 typeCheckAST b = S.evalState (typeCheckBlock b)
 
-runForEnv :: Block -> TypeEnv -> Either String TypeEnv 
-runForEnv b env = case S.runState (typeCheckBlock b) env of 
-    (Right (), finalStore) -> Right finalStore
-    (Left l, finalStore) -> Left l
-    
-throwError :: String -> LType -> Expression -> TypecheckerState a 
-throwError errorType expectedType exp = do 
-    eActualType <- synthesis exp 
-    case eActualType of 
-        Left error -> return $ Left error 
-        Right actualType -> return $ Left $  
-            errorType ++ ": expected type \
-            \[" ++ pretty expectedType ++ "]\
-            \ got type [" ++ pretty actualType ++ "]"
+runForEnv :: Block -> TypeEnv -> Either String TypeEnv
+runForEnv b env = case S.runState (typeCheckBlock b) env of
+  (Right (), finalStore) -> Right finalStore
+  (Left l, finalStore) -> Left l
 
+throwError :: String -> LType -> Expression -> TypecheckerState a
+throwError errorType expectedType exp = do
+  eActualType <- synthesis exp
+  case eActualType of
+    Left error -> return $ Left error
+    Right actualType ->
+      return $
+        Left $
+          errorType
+            ++ ": expected type \
+               \["
+            ++ pretty expectedType
+            ++ "]\
+               \ got type ["
+            ++ pretty actualType
+            ++ "]"
 
--- | typeCheck blocks individually, with some state. 
+-- | typeCheck blocks individually, with some state.
 typeCheckBlocks :: TypeEnv -> [Block] -> Either String ()
-typeCheckBlocks env = foldr checkBlock (Right ()) where 
-    checkBlock :: Block -> Either String () -> Either String () 
-    checkBlock b l@(Left _) = l 
+typeCheckBlocks env = foldr checkBlock (Right ())
+  where
+    checkBlock :: Block -> Either String () -> Either String ()
+    checkBlock b l@(Left _) = l
     checkBlock b _ = S.evalState (typeCheckBlock b) env
-    
+
 -- | Check that given expression is boolean, then check underlying blocks.
 typeCheckCondtionalBlocks :: Expression -> [Block] -> String -> TypecheckerState ()
-typeCheckCondtionalBlocks exp bs errorStr = do 
-    eRes <- checker exp BooleanType
-    curStore <- S.get
-    case eRes of 
-        Right True -> return $ typeCheckBlocks curStore bs
-        _ -> return $ Left errorStr
+typeCheckCondtionalBlocks exp bs errorStr = do
+  eRes <- checker exp BooleanType
+  curStore <- S.get
+  case eRes of
+    Right True -> return $ typeCheckBlocks curStore bs
+    _ -> return $ Left errorStr
 
--- | Given a block and an environment, check if the types are consistent in the block. 
+-- | Given a block and an environment, check if the types are consistent in the block.
 typeCheckBlock :: Block -> TypecheckerState ()
-typeCheckBlock (Block (s : ss)) = do 
-    curCheck <- typeCheckStatement s 
-    case curCheck of 
-        l@(Left _) -> return l 
-        Right () -> typeCheckBlock (Block ss)
+typeCheckBlock (Block (s : ss)) = do
+  curCheck <- typeCheckStatement s
+  case curCheck of
+    l@(Left _) -> return l
+    Right () -> typeCheckBlock (Block ss)
 typeCheckBlock (Block []) = return $ Right ()
 
--- | Given a statement and an environment, check if the types are consistent in the statement. 
+-- | Given a statement and an environment, check if the types are consistent in the statement.
 typeCheckStatement :: Statement -> TypecheckerState ()
-typeCheckStatement (Assign (v, UnknownType) exp) = do 
-    eTexp <- synthesis exp 
-    case eTexp of 
-        Right t -> typeCheckAssign v t exp 
-        Left l -> return $ Left l 
+typeCheckStatement (Assign (v, UnknownType) exp) = do
+  eTexp <- synthesis exp
+  case eTexp of
+    Right t -> typeCheckAssign v t exp
+    Left l -> return $ Left l
 typeCheckStatement (Assign (v, t) exp) = typeCheckAssign v t exp
 typeCheckStatement (If exp b1 b2) = typeCheckCondtionalBlocks exp [b1, b2] "Non-boolean in if condition"
 typeCheckStatement (While exp b) = typeCheckCondtionalBlocks exp [b] "Non-boolean in while condition"
-typeCheckStatement Empty = return $ Right ()  
+typeCheckStatement Empty = return $ Right ()
 typeCheckStatement (Repeat b exp) = typeCheckCondtionalBlocks exp [b] "Non-boolean in repeat condition"
-typeCheckStatement (Return exp) = do 
-    eExpectedType <- synth (Name returnTypeName)
-    case eExpectedType of 
+typeCheckStatement (Return exp) = do
+  eExpectedType <- synth (Name returnTypeName)
+  case eExpectedType of
+    Left error -> return $ Left error
+    Right expectedType -> do
+      eRes <- checker exp expectedType
+      case eRes of
         Left error -> return $ Left error
-        Right expectedType -> do 
-            eRes <- checker exp expectedType 
-            case eRes of 
-                Left error -> return $ Left error 
-                Right False -> throwError "Return:" expectedType exp 
-                Right True -> return $ Right () 
+        Right False -> throwError "Return:" expectedType exp
+        Right True -> return $ Right ()
 
 typeCheckAssign :: Var -> LType -> Expression -> TypecheckerState ()
 typeCheckAssign v UnknownType exp = return $ Left ("Can not determine type of [" ++ pretty exp ++ "]")
-typeCheckAssign v t exp = do 
-    doTypeAssignment v t exp -- Try to do type assignment, then evaluate expression type. (Recursive definitions)
-    eSameType <- checker exp t 
-    case eSameType of 
-        Left error -> return $ Left error 
-        Right False -> throwError "AssignmentError" t exp
-        Right True -> return $ Right ()
-    
-doTypeAssignment ::  Var -> LType -> Expression -> TypecheckerState ()
-doTypeAssignment (Name n) tExpType exp = do 
-    eCurrentType <- synth (Name n)
-    case eCurrentType of 
-        Left l -> return $ Left l
-        Right NilType -> updateEnv n tExpType exp
-        Right UnknownType -> return $ Left "Unable to determine type of expression in assignment"
-        Right curType -> if curType /= tExpType then 
-            return $ Left "Cannot redefine variable to new type"
-            else updateEnv n tExpType exp
-doTypeAssignment (Dot tExp n) vExpType _ = do 
-    eTExpType <- synthesis tExp 
-    return $ case eTExpType of 
-        Left l -> Left l 
-        Right tExpType -> typecheckTableAccess tExpType StringType vExpType
-doTypeAssignment (Proj tExp kExp) vExpType _ = do 
-    eKExpType <- synthesis kExp
-    eTExpType <- synthesis tExp
-    return $ case (eKExpType, eTExpType) of 
-        (Right kExpType, Right tExpType) -> typecheckTableAccess tExpType kExpType vExpType
-        (Left l, _) -> Left l 
-        (_, Left l) -> Left l
+typeCheckAssign v t exp = do
+  doTypeAssignment v t exp -- Try to do type assignment, then evaluate expression type. (Recursive definitions)
+  eSameType <- checker exp t
+  case eSameType of
+    Left error -> return $ Left error
+    Right False -> throwError "AssignmentError" t exp
+    Right True -> return $ Right ()
+
+doTypeAssignment :: Var -> LType -> Expression -> TypecheckerState ()
+doTypeAssignment (Name n) tExpType exp = do
+  eCurrentType <- synth (Name n)
+  case eCurrentType of
+    Left l -> return $ Left l
+    Right NilType -> updateEnv n tExpType exp
+    Right UnknownType -> return $ Left "Unable to determine type of expression in assignment"
+    Right curType ->
+      if curType /= tExpType
+        then return $ Left "Cannot redefine variable to new type"
+        else updateEnv n tExpType exp
+doTypeAssignment (Dot tExp n) vExpType _ = do
+  eTExpType <- synthesis tExp
+  return $ case eTExpType of
+    Left l -> Left l
+    Right tExpType -> typecheckTableAccess tExpType StringType vExpType
+doTypeAssignment (Proj tExp kExp) vExpType _ = do
+  eKExpType <- synthesis kExp
+  eTExpType <- synthesis tExp
+  return $ case (eKExpType, eTExpType) of
+    (Right kExpType, Right tExpType) -> typecheckTableAccess tExpType kExpType vExpType
+    (Left l, _) -> Left l
+    (_, Left l) -> Left l
 
 typecheckTableAccess :: LType -> LType -> LType -> Either String ()
-typecheckTableAccess (TableType kType vType) givenKType givenVType = 
-    if givenKType <: kType && givenVType <: vType 
-        then Right () 
-        else Left "Table type sealed"
-typecheckTableAccess _ _ _= Left "Unable to access value from non-table"
+typecheckTableAccess (TableType kType vType) givenKType givenVType =
+  if givenKType <: kType && givenVType <: vType
+    then Right ()
+    else Left "Table type sealed"
+typecheckTableAccess _ _ _ = Left "Unable to access value from non-table"
 
--- | Update variable type in store. 
+-- | Update variable type in store.
 updateEnv :: Name -> LType -> Expression -> TypecheckerState ()
-updateEnv n t exp = do 
-    env <- S.get 
-    S.modify (C.addGlobal (n, t))
-    case (t, exp) of 
-        (FunctionType _ _, Val f) -> do 
-            S.modify (addUncalledFunc (n, f))
-            return $ Right () 
-        _ -> return $ Right ()
+updateEnv n t exp = do
+  env <- S.get
+  S.modify (C.addGlobal (n, t))
+  case (t, exp) of
+    (FunctionType _ _, Val f) -> do
+      S.modify (addUncalledFunc (n, f))
+      return $ Right ()
+    _ -> return $ Right ()
 
-checkSameType :: Expression -> Expression -> TypecheckerState Bool 
-checkSameType e1 e2 = do 
-    eT1 <- synthesis e1 
-    eT2 <- synthesis e2
-    case (eT1, eT2) of 
-        (Right t1, Right t2) -> return $ Right (t1 <: t2 && t2 <: t1)
-        (Left error, _) -> return $ Left error
-        (_, Left error) -> return $ Left error
- 
-synthCall :: LType -> [Expression] -> TypecheckerState LType 
+checkSameType :: Expression -> Expression -> TypecheckerState Bool
+checkSameType e1 e2 = do
+  eT1 <- synthesis e1
+  eT2 <- synthesis e2
+  case (eT1, eT2) of
+    (Right t1, Right t2) -> return $ Right (t1 <: t2 && t2 <: t1)
+    (Left error, _) -> return $ Left error
+    (_, Left error) -> return $ Left error
+
+synthCall :: LType -> [Expression] -> TypecheckerState LType
 synthCall (FunctionType Never returnType) [] = return $ Right returnType
-synthCall (FunctionType paramType returnType) (p : ps) = do 
-    let nextFunction = if null ps then FunctionType Never returnType else returnType
-    eRes <- checker p paramType 
-    case eRes of 
-        (Left l) -> return $ Left l
-        Right False -> throwError "ParameterAssignment" paramType p
-        Right True -> synthCall nextFunction ps
+synthCall (FunctionType paramType returnType) (p : ps) = do
+  let nextFunction = if null ps then FunctionType Never returnType else returnType
+  eRes <- checker p paramType
+  case eRes of
+    (Left l) -> return $ Left l
+    Right False -> throwError "ParameterAssignment" paramType p
+    Right True -> synthCall nextFunction ps
 synthCall t _ = return $ Left ("CallNonFunc: Cannot call type [" ++ show t ++ "]")
 
-synthOp2 :: Bop -> Expression -> Expression -> TypecheckerState LType                            
-synthOp2 op e1 e2 = do 
-            eOpType <- synth op 
-            case eOpType of 
-                Right opType -> synthCall opType [e1, e2]
-                (Left error) -> return $ Left error
+synthOp2 :: Bop -> Expression -> Expression -> TypecheckerState LType
+synthOp2 op e1 e2 = do
+  eOpType <- synth op
+  case eOpType of
+    Right opType -> synthCall opType [e1, e2]
+    (Left error) -> return $ Left error
 
-synthOp2Poly :: Bop -> Expression -> Expression -> TypecheckerState LType 
-synthOp2Poly op e1 e2 = do 
-    eSameType <- checkSameType e1 e2 
-    case eSameType of 
-        Right False -> return $ Left "Recieved two different types in Op2 execution."
-        (Left error) -> return $ Left error
-        Right True -> synthOp2 op e1 e2
+synthOp2Poly :: Bop -> Expression -> Expression -> TypecheckerState LType
+synthOp2Poly op e1 e2 = do
+  eSameType <- checkSameType e1 e2
+  case eSameType of
+    Right False -> return $ Left "Recieved two different types in Op2 execution."
+    (Left error) -> return $ Left error
+    Right True -> synthOp2 op e1 e2
 
-typeCheckFuncBody :: Name -> TypecheckerState () 
-typeCheckFuncBody n = do 
-    s <- S.get 
-    let funcValue = getUncalledFunc s n  
-    case funcValue of 
-        Just (FunctionVal pms rt b) -> do 
-            C.prepareFunctionEnv ((returnTypeName, rt) : pms)
-            S.modify (\env -> removeUncalledFunc env n)
-            res <- typeCheckBlock b 
-            S.modify C.exitScope 
-            return res
-        _ -> return $ Right ()
+typeCheckFuncBody :: Name -> TypecheckerState ()
+typeCheckFuncBody n = do
+  s <- S.get
+  let funcValue = getUncalledFunc s n
+  case funcValue of
+    Just (FunctionVal pms rt b) -> do
+      C.prepareFunctionEnv ((returnTypeName, rt) : pms)
+      S.modify (\env -> removeUncalledFunc env n)
+      res <- typeCheckBlock b
+      S.modify C.exitScope
+      return res
+    _ -> return $ Right ()
 
-synthesis :: Expression -> TypecheckerState LType  
-synthesis (Op2 exp1 bop exp2) | isPolymorphicBop bop = synthOp2Poly bop exp1 exp2   
+synthesis :: Expression -> TypecheckerState LType
+synthesis (Op2 exp1 bop exp2) | isPolymorphicBop bop = synthOp2Poly bop exp1 exp2
 synthesis (Op2 exp1 bop exp2) = synthOp2 bop exp1 exp2
 synthesis (Val v) = synth v
 synthesis (Var v) = synth v
 synthesis (TableConst tfs) = synth tfs
-synthesis (Call (Name n) pms) = do 
-    eFType <- synth (Name n) 
-    case eFType of 
-        Left error -> return $ Left error 
-        Right fType -> do 
-            let res = synthCall fType pms
-            fBodyCheck <- typeCheckFuncBody n 
-            case fBodyCheck of 
-                Left error -> return $ Left error
-                Right () -> res
-synthesis (Op1 uop exp) = do 
-    eOpType <- synth uop
-    case eOpType of 
-        Right opType -> synthCall opType [exp]
-        l@(Left _) -> return l
+synthesis (Call (Name n) pms) = do
+  eFType <- synth (Name n)
+  case eFType of
+    Left error -> return $ Left error
+    Right fType -> do
+      let res = synthCall fType pms
+      fBodyCheck <- typeCheckFuncBody n
+      case fBodyCheck of
+        Left error -> return $ Left error
+        Right () -> res
+synthesis (Op1 uop exp) = do
+  eOpType <- synth uop
+  case eOpType of
+    Right opType -> synthCall opType [exp]
+    l@(Left _) -> return l
 synthesis (Call v pms) = undefined
 
-checker :: Expression -> LType -> TypecheckerState Bool 
-checker exp expectedType = do 
-    eType <- synthesis exp 
-    return $ case eType of 
-        Left l -> Left l
-        Right actualType -> Right $ actualType <: expectedType
+checker :: Expression -> LType -> TypecheckerState Bool
+checker exp expectedType = do
+  eType <- synthesis exp
+  return $ case eType of
+    Left l -> Left l
+    Right actualType -> Right $ actualType <: expectedType
 
-runSynthesis :: TypeEnv -> Expression -> LType 
-runSynthesis env exp = case S.evalState (synthesis exp) env of 
-    Right t -> t 
-    Left _ -> UnknownType
+runSynthesis :: TypeEnv -> Expression -> LType
+runSynthesis env exp = case S.evalState (synthesis exp) env of
+  Right t -> t
+  Left _ -> UnknownType
 
--- | Check that type of given expression is an instance of given type. 
+-- | Check that type of given expression is an instance of given type.
 runChecker :: TypeEnv -> Expression -> LType -> Bool
 runChecker env e = (<:) (runSynthesis env e)

--- a/test/LuE2ETest.hs
+++ b/test/LuE2ETest.hs
@@ -1,234 +1,218 @@
-module LuE2ETest where 
+module LuE2ETest where
 
-import Test.HUnit (Counts, Test (..), runTestTT, (~:), (~?=), assert)
-import LuParser (parseLuFile)
-import LuEvaluator (Store, eval, globalTableName, EvalEnv, toStore, errorCodeName, haltFlagName, exec)
-import LuEvaluatorTest (initialEnv)
-import LuTypeChecker (typeCheckAST, runForEnv, getUncalledFunc, TypeEnv, contextLookup)
-import Context (Context, ExtendedContext) 
+import Context (Context, ExtendedContext)
 import Context qualified as C
+import Data.Map qualified as Map
+import LuEvaluator (EvalEnv, Store, errorCodeName, eval, exec, globalTableName, haltFlagName, toStore)
+import LuEvaluatorTest (initialEnv)
+import LuParser (parseLuFile)
 import LuSyntax
+import LuTypeChecker (TypeEnv, contextLookup, getUncalledFunc, runForEnv, typeCheckAST)
 import LuTypes
 import State qualified as S
-import Data.Map qualified as Map
+import Test.HUnit (Counts, Test (..), assert, runTestTT, (~:), (~?=))
 
-
-processFileForStore :: ExtendedContext env => String -> (Block -> env -> Either String env) -> IO (Either String env)
-processFileForStore fp execBlock = do 
-    parseResult <- parseLuFile fp 
-    return $ case parseResult of 
-        (Left _) -> Left "Failed to parse file"
-        (Right ast) -> execBlock ast C.emptyContext
+processFileForStore :: (ExtendedContext env) => String -> (Block -> env -> Either String env) -> IO (Either String env)
+processFileForStore fp execBlock = do
+  parseResult <- parseLuFile fp
+  return $ case parseResult of
+    (Left _) -> Left "Failed to parse file"
+    (Right ast) -> execBlock ast C.emptyContext
 
 -- | Parse and run file to get resulting Store (or error message)
-runFileForStore :: String -> IO (Either String EvalEnv)
-runFileForStore fp = processFileForStore fp exec 
+evalFileForStore :: String -> IO (Either String EvalEnv)
+evalFileForStore fp = processFileForStore fp exec
 
-typeCheckFileForStore :: String -> IO (Either String TypeEnv) 
+typeCheckFileForStore :: String -> IO (Either String TypeEnv)
 typeCheckFileForStore fp = processFileForStore fp runForEnv
 
 checkThrowsError :: String -> String -> IO Bool
-checkThrowsError fp err = do 
-    result <- runFileForStore fp 
-    return $ case result of 
-        Left s -> s == err 
-        _ -> False
+checkThrowsError fp err = do
+  result <- evalFileForStore fp
+  return $ case result of
+    Left s -> s == err
+    _ -> False
 
-testIOResult :: IO Bool -> IO () 
+testIOResult :: IO Bool -> IO ()
 testIOResult b = b >>= assert
 
+checkVarProperty :: String -> (Value -> Bool) -> EvalEnv -> Either String Bool
+checkVarProperty targetName property s = case Map.lookup globalTableName (toStore s) of
+  Nothing -> Left "Failed to find global table."
+  Just globalTable -> case Map.lookup (StringVal targetName) globalTable of
+    Nothing -> Left ("Failed to find" ++ targetName ++ "variable")
+    Just v -> Right $ property v
 
-checkVarProperty :: String -> (Value -> Bool) -> EvalEnv -> Either String Bool 
-checkVarProperty targetName property s = case Map.lookup globalTableName (toStore s) of 
-    Nothing -> Left "Failed to find global table."
-    Just globalTable -> case Map.lookup (StringVal targetName) globalTable of 
-        Nothing -> Left ("Failed to find" ++ targetName ++  "variable")
-        Just v -> Right $ property v
-
--- | Check if variable holds value in store. 
-checkVarValueInStore :: String -> Value -> EvalEnv -> Either String Bool 
-checkVarValueInStore targetName targetValue = checkVarProperty targetName (== targetValue) 
+-- | Check if variable holds value in store.
+checkVarValueInStore :: String -> Value -> EvalEnv -> Either String Bool
+checkVarValueInStore targetName targetValue = checkVarProperty targetName (== targetValue)
 
 -- | Concise way to check multiple variable values.
-checkVarValuesInStore :: [(String, Value)] -> EvalEnv -> Either String Bool 
-checkVarValuesInStore valuePairs s = let results = map (\(n, v) -> checkVarValueInStore n v s) valuePairs in 
-    return $ all didFail results 
-    where 
-        didFail :: Either String Bool -> Bool
-        didFail (Right True) = True 
-        didFail _ = False
-        
--- | Check if variable holds value in store. 
-checkVarExistsInStore :: String -> EvalEnv -> Either String Bool 
+checkVarValuesInStore :: [(String, Value)] -> EvalEnv -> Either String Bool
+checkVarValuesInStore valuePairs s =
+  let results = map (\(n, v) -> checkVarValueInStore n v s) valuePairs
+   in return $ all didFail results
+  where
+    didFail :: Either String Bool -> Bool
+    didFail (Right True) = True
+    didFail _ = False
+
+-- | Check if variable holds value in store.
+checkVarExistsInStore :: String -> EvalEnv -> Either String Bool
 checkVarExistsInStore targetName = checkVarProperty targetName (const True)
 
--- | Apply target function to final store of given file. 
+-- | Apply target function to final store of given file.
 -- Ex. checkFileOutputStore "test/lu/if1.lu" (checkVarValue "result" (IntVal 5)) ==> Right True
---     since final value of "result" is (IntVal 5).    
+--     since final value of "result" is (IntVal 5).
 checkFileOutputStore :: String -> (EvalEnv -> Either String Bool) -> IO (Either String Bool)
-checkFileOutputStore fp checkFn = do 
-    finalState <- runFileForStore fp 
-    case finalState of 
-        (Left _) -> return $ Left "Failed to retrieve store"
-        (Right s) -> return $ checkFn s
+checkFileOutputStore fp checkFn = do
+  finalState <- evalFileForStore fp
+  case finalState of
+    (Left _) -> return $ Left "Failed to retrieve store"
+    (Right s) -> return $ checkFn s
 
 checkFileTypeStore :: String -> (TypeEnv -> Either String Bool) -> IO (Either String Bool)
-checkFileTypeStore fp checkFn = do 
-    finalStore <- typeCheckFileForStore fp 
-    case finalStore of 
-        (Left _) -> return $ Left "Failed to retrieve store"
-        (Right s) -> do 
-            return $ checkFn s
+checkFileTypeStore fp checkFn = do
+  finalStore <- typeCheckFileForStore fp
+  case finalStore of
+    (Left _) -> return $ Left "Failed to retrieve store"
+    (Right s) -> do
+      return $ checkFn s
 
-
-testTypeCheckFile :: String -> Bool -> IO () 
+testTypeCheckFile :: String -> Bool -> IO ()
 testTypeCheckFile fp flipped = do
-    parseResult <- parseLuFile fp 
-    case parseResult of 
-        (Left l) -> assert False
-        Right ast -> case typeCheckAST ast C.emptyContext of 
-            (Left l) -> assert (not flipped)
-            _ -> assert flipped
+  parseResult <- parseLuFile fp
+  case parseResult of
+    (Left l) -> assert False
+    Right ast -> case typeCheckAST ast C.emptyContext of
+      (Left l) -> assert (not flipped)
+      _ -> assert flipped
 
 getTypeEnvFile :: String -> IO (Either String TypeEnv)
-getTypeEnvFile fp = do 
-    parseResult <- parseLuFile fp 
-    case parseResult of 
-        (Left l) -> return $ Left l
-        Right ast -> case runForEnv ast C.emptyContext of 
-            (Left l2) -> return $ Left l2
-            Right store -> return $ Right store
+getTypeEnvFile fp = do
+  parseResult <- parseLuFile fp
+  case parseResult of
+    (Left l) -> return $ Left l
+    Right ast -> case runForEnv ast C.emptyContext of
+      (Left l2) -> return $ Left l2
+      Right store -> return $ Right store
 
-seeTypeStore :: String -> IO () 
-seeTypeStore fp = do 
-    r <- getTypeEnvFile fp 
-    case r of 
-        Left l -> putStrLn (show l )
-        Right r -> putStrLn (show  r)
+seeTypeStore :: String -> IO ()
+seeTypeStore fp = do
+  r <- getTypeEnvFile fp
+  case r of
+    Left l -> putStrLn (show l)
+    Right r -> putStrLn (show r)
 
+testEvalFile :: String -> (EvalEnv -> Either String Bool) -> IO ()
+testEvalFile fp checkFn = do
+  res <- checkFileOutputStore fp checkFn
+  case res of
+    Right True -> assert True
+    _ -> assert False
 
-testEvalFile :: String -> (EvalEnv -> Either String Bool) -> IO () 
-testEvalFile fp checkFn = do 
-    res <- checkFileOutputStore fp checkFn
-    case res of 
-        Right True -> assert True 
-        _ -> assert False
+testTypeCheckFileStore :: String -> (TypeEnv -> Either String Bool) -> IO ()
+testTypeCheckFileStore fp checkFn = do
+  res <- checkFileTypeStore fp checkFn
+  case res of
+    Right True -> assert True
+    _ -> assert False
 
-testTypeCheckFileStore :: String -> (TypeEnv -> Either String Bool) -> IO () 
-testTypeCheckFileStore fp checkFn = do 
-    res <- checkFileTypeStore fp checkFn
-    case res of 
-        Right True -> assert True 
-        _ -> assert False
+test_if :: Test
+test_if =
+  "e2e testing if" ~:
+    TestList
+      [ "if1" ~: testEvalFile "test/lu/if1.lu" (checkVarValueInStore "result" (IntVal 5)),
+        "if2" ~: testEvalFile "test/lu/if2.lu" (checkVarValueInStore "result" (StringVal "hello"))
+      ]
 
--- showTypeEnvFile :: String -> IO () 
--- showTypeEnvFile fp = do 
---     res <- getTypeEnvFile fp 
---     case res of 
---         Left l -> putStrLn l 
---         Right s -> putStrLn (show s)
+test_function :: Test
+test_function =
+  "e2e function" ~:
+    TestList
+      [ "function1" ~: testEvalFile "test/lu/function1.lu" (checkVarExistsInStore "foo"),
+        "function2" ~: testEvalFile "test/lu/function2.lu" (checkVarValuesInStore [("z", IntVal 11)]),
+        "function3" ~: testEvalFile "test/lu/function3.lu" (checkVarValuesInStore [("z", BoolVal False), ("s", StringVal "True"), ("x", IntVal 1), ("y", IntVal 2), ("result", IntVal (-1))]),
+        "function4" ~: testEvalFile "test/lu/function4.lu" (checkVarValueInStore "z" (IntVal 5)),
+        "function5" ~: testEvalFile "test/lu/function5.lu" (checkVarValuesInStore [("z", StringVal "foo"), ("x", IntVal 1)]),
+        "function6" ~: testEvalFile "test/lu/function6.lu" (checkVarValuesInStore [("f", BoolVal False), ("z", IntVal 1)]),
+        "recFunction" ~: testEvalFile "test/lu/recFunction.lu" (checkVarValueInStore "z" (IntVal 720)),
+        "weirdScopesFunc" ~: testEvalFile "test/lu/weirdScopesFunc.lu" (checkVarValuesInStore [("result", IntVal 18), ("result2", IntVal 12)]),
+        "unionTypeFunc" ~: testEvalFile "test/lu/unionTypeFunc.lu" (checkVarExistsInStore "foo"),
+        "function7" ~: testEvalFile "test/lu/function7.lu" (checkVarValuesInStore [("b", IntVal 10), ("z", IntVal 8)]),
+        "nameShadow" ~: testEvalFile "test/lu/nameShadow.lu" (checkVarValuesInStore [("res", IntVal 10), ("s", StringVal "s")])
+      ]
 
-test_if :: Test 
-test_if = 
-    "e2e testing if" ~:
-        TestList 
-          [
-            "if1" ~: testEvalFile "test/lu/if1.lu" (checkVarValueInStore "result" (IntVal 5)), 
-            "if2" ~: testEvalFile "test/lu/if2.lu" (checkVarValueInStore "result" (StringVal "hello"))
-          ]
+test_typeSig :: Test
+test_typeSig =
+  "e2e typeSig" ~:
+    TestList
+      [ "optionalSig1" ~: testEvalFile "test/lu/optionalSig1.lu" (checkVarValuesInStore [("x", IntVal 5), ("x2", IntVal 5), ("s", StringVal "hello"), ("s2", StringVal "hello"), ("z", BoolVal True), ("z2", BoolVal True)]),
+        "optionalSig2" ~: testEvalFile "test/lu/optionalSig2.lu" (checkVarExistsInStore "f" >> checkVarExistsInStore "u")
+      ]
 
+test_typeCheck :: Test
+test_typeCheck =
+  "testing type checker" ~:
+    TestList
+      [ "abs" ~: testTypeCheckFile "test/lu/abs.lu" True,
+        "exp" ~: testTypeCheckFile "test/lu/exp.lu" False,
+        "fact" ~: testTypeCheckFile "test/lu/fact.lu" True,
+        "repeat" ~: testTypeCheckFile "test/lu/repeat.lu" True,
+        "table" ~: testTypeCheckFile "test/lu/table.lu" False,
+        "test" ~: testTypeCheckFile "test/lu/test.lu" True,
+        "bfs" ~: testTypeCheckFile "test/lu/bfs.lu" False,
+        "times" ~: testTypeCheckFile "test/lu/times.lu" True,
+        "optionalSig1" ~: testTypeCheckFile "test/lu/optionalSig1.lu" True,
+        "optionalSig2" ~: testTypeCheckFile "test/lu/optionalSig2.lu" True,
+        "recFunction" ~: testTypeCheckFile "test/lu/recFunction.lu" True,
+        "function1" ~: testTypeCheckFile "test/lu/function1.lu" True,
+        "function2" ~: testTypeCheckFile "test/lu/function2.lu" True,
+        "function3" ~: testTypeCheckFile "test/lu/function3.lu" True,
+        "function4" ~: testTypeCheckFile "test/lu/function4.lu" True,
+        "function5" ~: testTypeCheckFile "test/lu/function5.lu" True,
+        "function6" ~: testTypeCheckFile "test/lu/function6.lu" True,
+        "function7" ~: testTypeCheckFile "test/lu/function7.lu" True,
+        "function8" ~: testTypeCheckFile "test/lu/function8.lu" True,
+        "unionTypeFunc" ~: testTypeCheckFile "test/lu/unionTypeFunc.lu" False,
+        "weirdScopesFunc" ~: testTypeCheckFile "test/lu/weirdScopesFunc.lu" True,
+        "nestedGlobal" ~: testTypeCheckFile "test/lu/nestedGlobal.lu" False,
+        "nestedGlobal2" ~: testTypeCheckFile "test/lu/nestedGlobal2.lu" True,
+        "nestedFuncReturnTypeGood" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeGood.lu" True,
+        "nestedFuncReturnTypeBad" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeBad.lu" False,
+        "nestedFuncReturnTypeBad2" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeBad2.lu" False,
+        "nameShadow" ~: testTypeCheckFile "test/lu/nameShadow.lu" True,
+        "nameShadowBad" ~: testTypeCheckFile "test/lu/nameShadowBad.lu" False,
+        "unionReturn" ~: testTypeCheckFile "test/lu/unionReturn.lu" False
+      ]
 
-test_function :: Test 
-test_function = 
-    "e2e function" ~: 
-        TestList 
-           [
-             "function1" ~: testEvalFile "test/lu/function1.lu" (checkVarExistsInStore "foo"), 
-             "function2" ~: testEvalFile "test/lu/function2.lu" (checkVarValuesInStore [("z", IntVal 11)]), 
-             "function3" ~: testEvalFile "test/lu/function3.lu" (checkVarValuesInStore [("z", BoolVal False), ("s", StringVal "True"), ("x", IntVal 1), ("y", IntVal 2), ("result", IntVal (-1))]), 
-             "function4" ~: testEvalFile "test/lu/function4.lu" (checkVarValueInStore "z" (IntVal 5)), 
-             "function5" ~: testEvalFile "test/lu/function5.lu" (checkVarValuesInStore [("z", StringVal "foo"), ("x", IntVal 1)]), 
-             "function6" ~: testEvalFile "test/lu/function6.lu" (checkVarValuesInStore [("f", BoolVal False), ("z", IntVal 1)]), 
-             "recFunction" ~: testEvalFile "test/lu/recFunction.lu" (checkVarValueInStore "z" (IntVal 720)), 
-             "weirdScopesFunc" ~: testEvalFile "test/lu/weirdScopesFunc.lu" (checkVarValuesInStore [("result", IntVal 18), ("result2", IntVal 12)]), 
-             "unionTypeFunc" ~: testEvalFile "test/lu/unionTypeFunc.lu" (checkVarExistsInStore "foo"), 
-             "function7" ~: testEvalFile "test/lu/function7.lu" (checkVarValuesInStore [("b", IntVal 10), ("z", IntVal 8)]), 
-             "nameShadow" ~: testEvalFile "test/lu/nameShadow.lu" (checkVarValuesInStore [("res", IntVal 10), ("s", StringVal "s")])
-           ]
-test_typeSig :: Test 
-test_typeSig = 
-    "e2e typeSig" ~: 
-        TestList 
-            [
-                "optionalSig1" ~: testEvalFile "test/lu/optionalSig1.lu" (checkVarValuesInStore [("x", IntVal 5), ("x2", IntVal 5), ("s", StringVal "hello"), ("s2", StringVal "hello"), ("z", BoolVal True), ("z2", BoolVal True)]), 
-                "optionalSig2" ~: testEvalFile "test/lu/optionalSig2.lu" (checkVarExistsInStore "f" >> checkVarExistsInStore "u")
-            ]
+test_typeCheckStore :: Test
+test_typeCheckStore =
+  "tesing type checker store" ~:
+    TestList
+      [ "uncalledFunc" ~: testTypeCheckFileStore "test/lu/uncalledFunc.lu" (containsFunc "foo"),
+        "uncalledFunc" ~: testTypeCheckFileStore "test/lu/uncalledFunc.lu" (isNilOrUndefined "z" False),
+        "calledFunc" ~: testTypeCheckFileStore "test/lu/calledFunc.lu" (isNilOrUndefined "z" True)
+      ]
+  where
+    containsFunc :: Name -> TypeEnv -> Either String Bool
+    containsFunc n env = case getUncalledFunc env n of
+      Just _ -> return True
+      _ -> Left "Failed to find"
 
-test_typeCheck :: Test 
-test_typeCheck = 
-    "testing type checker" ~: 
-        TestList 
-            [
-                "abs" ~: testTypeCheckFile "test/lu/abs.lu" True, 
-                "exp" ~: testTypeCheckFile "test/lu/exp.lu" False, 
-                "fact" ~: testTypeCheckFile "test/lu/fact.lu" True, 
-                "repeat" ~: testTypeCheckFile "test/lu/repeat.lu" True, 
-                "table" ~: testTypeCheckFile "test/lu/table.lu" False, 
-                "test" ~: testTypeCheckFile "test/lu/test.lu" True, 
-                "bfs" ~: testTypeCheckFile "test/lu/bfs.lu" False, 
-                "times" ~: testTypeCheckFile "test/lu/times.lu" True, 
-                "optionalSig1" ~: testTypeCheckFile "test/lu/optionalSig1.lu" True, 
-                "optionalSig2" ~: testTypeCheckFile "test/lu/optionalSig2.lu" True, 
-                "recFunction" ~: testTypeCheckFile "test/lu/recFunction.lu" True, 
-                "function1" ~: testTypeCheckFile "test/lu/function1.lu" True, 
-                "function2" ~: testTypeCheckFile "test/lu/function2.lu" True, 
-                "function3" ~: testTypeCheckFile "test/lu/function3.lu" True, 
-                "function4" ~: testTypeCheckFile "test/lu/function4.lu" True, 
-                "function5" ~: testTypeCheckFile "test/lu/function5.lu" True, 
-                "function6" ~: testTypeCheckFile "test/lu/function6.lu" True, 
-                "function7" ~: testTypeCheckFile "test/lu/function7.lu" True, 
-                "function8" ~: testTypeCheckFile "test/lu/function8.lu" True, 
-                "unionTypeFunc" ~: testTypeCheckFile "test/lu/unionTypeFunc.lu" False, 
-                "weirdScopesFunc" ~: testTypeCheckFile "test/lu/weirdScopesFunc.lu" True, 
-                "nestedGlobal" ~: testTypeCheckFile "test/lu/nestedGlobal.lu" False, 
-                "nestedGlobal2" ~: testTypeCheckFile "test/lu/nestedGlobal2.lu" True, 
-                "nestedFuncReturnTypeGood" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeGood.lu" True, 
-                "nestedFuncReturnTypeBad" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeBad.lu" False,
-                "nestedFuncReturnTypeBad2" ~: testTypeCheckFile "test/lu/nestedFuncReturnTypeBad2.lu" False, 
-                "nameShadow" ~: testTypeCheckFile "test/lu/nameShadow.lu" True, 
-                "nameShadowBad" ~: testTypeCheckFile "test/lu/nameShadowBad.lu" False, 
-                "unionReturn" ~: testTypeCheckFile "test/lu/unionReturn.lu" False 
+    isNilOrUndefined :: Name -> Bool -> TypeEnv -> Either String Bool
+    isNilOrUndefined n expected env = case S.evalState (contextLookup n) env of
+      NilType -> return expected
+      UnknownType -> return expected
+      _ -> return (not expected)
 
-            ]
+test_error :: Test
+test_error =
+  "e2e error" ~:
+    TestList
+      [ "IllegalArguments1" ~: testIOResult $ checkThrowsError "test/lu/error1.lu" (show IllegalArguments),
+        "DivideByZero" ~: testIOResult $ checkThrowsError "test/lu/error2.lu" (show DivideByZero)
+      ]
 
-test_typeCheckStore :: Test 
-test_typeCheckStore = 
-    "tesing type checker store" ~:
-        TestList 
-            [
-                "uncalledFunc" ~: testTypeCheckFileStore "test/lu/uncalledFunc.lu" (containsFunc "foo"), 
-                "uncalledFunc" ~: testTypeCheckFileStore "test/lu/uncalledFunc.lu" (isNilOrUndefined "z" False),
-                "calledFunc" ~: testTypeCheckFileStore "test/lu/calledFunc.lu" (isNilOrUndefined "z" True)
-
-            ] where 
-                containsFunc :: Name -> TypeEnv -> Either String Bool 
-                containsFunc n env = case getUncalledFunc env n of 
-                    Just _ -> return True 
-                    _ -> Left "Failed to find"
-
-                isNilOrUndefined :: Name -> Bool -> TypeEnv -> Either String Bool 
-                isNilOrUndefined n expected env = case S.evalState (contextLookup n) env of 
-                    NilType -> return expected 
-                    UnknownType -> return expected
-                    _ -> return (not expected)
-
-test_error :: Test 
-test_error = 
-    "e2e error" ~: 
-        TestList 
-            [ 
-                "IllegalArguments1" ~: testIOResult $ checkThrowsError "test/lu/error1.lu" (show IllegalArguments), 
-                "DivideByZero" ~: testIOResult $ checkThrowsError "test/lu/error2.lu" (show DivideByZero)
-            ]
-test :: IO Counts 
+test :: IO Counts
 test = runTestTT $ TestList [test_if, test_function, test_typeSig, test_error]

--- a/test/LuEvaluatorTest.hs
+++ b/test/LuEvaluatorTest.hs
@@ -201,13 +201,13 @@ test_error =
 tExecTest :: Test
 tExecTest =
   "exec wTest" ~:
-    toStore (exec wTest initialEnv)
+    toStore (execWithoutError wTest initialEnv)
       ~?= Map.fromList [(globalTableName, Map.fromList [(StringVal "x", IntVal 0), (StringVal "y", IntVal 10)])]
 
 tExecFact :: Test
 tExecFact =
   "exec wFact" ~:
-    toStore (exec wFact initialEnv)
+    toStore (execWithoutError wFact initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList
@@ -222,7 +222,7 @@ tExecFact =
 tExecAbs :: Test
 tExecAbs =
   "exec wAbs" ~:
-    toStore (exec wAbs initialEnv)
+    toStore (execWithoutError wAbs initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList [(StringVal "x", IntVal 3)]
@@ -232,7 +232,7 @@ tExecAbs =
 tExecTimes :: Test
 tExecTimes =
   "exec wTimes" ~:
-    toStore (exec wTimes initialEnv)
+    toStore (execWithoutError wTimes initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList [(StringVal "x", IntVal 0), (StringVal "y", IntVal 3), (StringVal "z", IntVal 30)]
@@ -242,7 +242,7 @@ tExecTimes =
 tExecTable :: Test
 tExecTable =
   "exec wTable" ~:
-    toStore (exec wTable initialEnv)
+    toStore (execWithoutError wTable initialEnv)
       ~?= Map.fromList
         [ ( globalTableName,
             Map.fromList
@@ -259,7 +259,7 @@ tExecTable =
 tExecBfs :: Test
 tExecBfs = "exec wBfs" ~: TestList [global !? StringVal "found" ~?= Just (BoolVal True)]
   where
-    ss = toStore (exec wBfs initialEnv)
+    ss = toStore (execWithoutError wBfs initialEnv)
     global = case ss !? globalTableName of
       Just g -> g
       Nothing -> Map.empty

--- a/test/LuStepperTest.hs
+++ b/test/LuStepperTest.hs
@@ -2,7 +2,7 @@ module LuStepperTest where
 
 import LuSyntax
 import LuStepper
-import LuEvaluator (EvalEnv, globalTableName, exec, toStore, Store, fromStore)
+import LuEvaluator (EvalEnv, globalTableName, execWithoutError, toStore, Store, fromStore)
 import LuEvaluatorTest (initialEnv, extendedEnv)
 import State (State)
 import State qualified as S
@@ -88,7 +88,7 @@ test_step_with_errors =
   "exec with errors" ~: 
     TestList 
       [
-        toStore (exec b initialEnv) ~?= toStore (S.execState (boundedStep 100 b) initialEnv)
+        toStore (execWithoutError b initialEnv) ~?= toStore (S.execState (boundedStep 100 b) initialEnv)
       ]
       where 
           b = Block [If (Op1 Neg (Var (Name "x"))) (Block []) (Block []),If (TableConst []) (Block []) (Block [])]
@@ -101,7 +101,7 @@ prop_stepExec b =
   not (final b) QC.==> final b1 QC.==> toStore m1 == toStore m2
   where
     (b1, m1) = S.runState (boundedStep 100 b) initialEnv
-    m2 = exec b initialEnv
+    m2 = execWithoutError b initialEnv
 
 -- | Make sure that we can step every block in every store
 prop_step_total :: Block -> Store -> Bool


### PR DESCRIPTION
As a another application of type classes, we can generalize a `TestableEnvironment` such that we can avoid writing the same code to test both type checking and evaluation. 

Ignore massive line change, its all formatting. 